### PR TITLE
feat: search filters clickable + fix: search filter display on url refresh

### DIFF
--- a/frontend/src/components/ReworkComponents/generic/Header/Header.tsx
+++ b/frontend/src/components/ReworkComponents/generic/Header/Header.tsx
@@ -34,6 +34,7 @@ const Header: FC<HeaderProps> = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [videos] = useState<Video[]>([]);
+  const location = useLocation();
   const [showFilters, setShowFilters] = useState(false);
   const [, setFilteredVideos] = useState<Video[]>([]);
   const filterPanelRef = useRef<HTMLDivElement | null>(null);
@@ -254,6 +255,31 @@ const Header: FC<HeaderProps> = () => {
     endDate: null,
     archived: null,
   });
+
+  // Sync filters and searchQuery from URL on mount and whenever the URL changes
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const urlTags = params.get('tags')?.split(',').filter(Boolean) ?? [];
+    const urlUsers = params.get('users')?.split(',').filter(Boolean) ?? [];
+    const urlDateFrom = params.get('dateFrom') || null;
+    const urlDateTo = params.get('dateTo') || null;
+    const urlArchived =
+      params.get('archived') === 'true'
+        ? true
+        : params.get('archived') === 'false'
+          ? false
+          : null;
+    const urlQuery = params.get('q') || '';
+
+    setFilters({
+      tags: urlTags,
+      users: urlUsers,
+      startDate: urlDateFrom ? new Date(urlDateFrom) : null,
+      endDate: urlDateTo ? new Date(urlDateTo) : null,
+      archived: urlArchived,
+    });
+    setSearchQuery(urlQuery);
+  }, [location.search]);
 
   const buildGlobalSearchUrl = useCallback(
     (overrides: Partial<SearchState> = {}) => {

--- a/frontend/src/pages/globalSearch/globalSearch.module.css
+++ b/frontend/src/pages/globalSearch/globalSearch.module.css
@@ -59,10 +59,88 @@
   font-size: 0.82rem;
   letter-spacing: 0.02em;
   white-space: nowrap;
+  font-family: inherit;
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  user-select: none;
+}
+
+.resultMetaChip {
+  cursor: pointer;
+}
+
+.resultMetaChip:hover {
+  background: #f5f5f5;
+  border-color: rgba(0, 0, 0, 0.16);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.resultMetaChip:active {
+  transform: translateY(0);
+}
+
+/* Dimmed state when another filter is active */
+.dimmedChip {
+  opacity: 0.45;
+  transform: scale(0.96);
+}
+
+.dimmedChip:hover {
+  opacity: 0.8;
+  transform: scale(0.98);
+}
+
+/* Active / Highlighted state */
+.activeChip {
+  background: var(--theme-color);
+  color: var(--theme-color-white);
+  border-color: var(--theme-color);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  font-weight: 500;
+}
+
+.activeChip:hover {
+  background: var(--theme-color);
+  border-color: var(--theme-color);
+  color: var(--theme-color-white);
+  opacity: 0.95;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
 }
 
 .resultMetaChipAccent {
   background: linear-gradient(135deg, rgba(28, 28, 28, 0.04), rgba(28, 28, 28, 0.08));
+}
+
+.clickableTotal {
+  cursor: pointer;
+  border: 1px dashed rgba(0, 0, 0, 0.2);
+}
+
+.clickableTotal:hover {
+  background: #f0f0f0;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.3);
+  transform: translateY(-1px);
+}
+
+.checkmarkIcon {
+  flex-shrink: 0;
+  animation: scaleIn 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .errorBanner {

--- a/frontend/src/pages/globalSearch/globalSearch.tsx
+++ b/frontend/src/pages/globalSearch/globalSearch.tsx
@@ -257,6 +257,13 @@ const GlobalSearchPage = () => {
   const [fallbackMiniatureUrl, setFallbackMiniatureUrl] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [filterType, setFilterType] = useState<'all' | 'events' | 'videos'>(
+    'all',
+  );
+
+  useEffect(() => {
+    setFilterType('all');
+  }, [location.search]);
 
   useEffect(() => {
     let active = true;
@@ -405,15 +412,79 @@ const GlobalSearchPage = () => {
             className={styles.resultMeta}
             aria-label={t('globalSearchTotal')}
           >
-            <span className={styles.resultMetaChip}>
+            <button
+              type="button"
+              className={`${styles.resultMetaChip} ${
+                filterType === 'events'
+                  ? styles.activeChip
+                  : filterType !== 'all'
+                    ? styles.dimmedChip
+                    : ''
+              }`}
+              onClick={() =>
+                setFilterType(filterType === 'events' ? 'all' : 'events')
+              }
+            >
+              {filterType === 'events' && (
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className={styles.checkmarkIcon}
+                >
+                  <polyline points="10 3 4.5 8.5 2 6" />
+                </svg>
+              )}
               {t('globalSearchEventsCount', { count: filteredEvents.length })}
-            </span>
-            <span className={styles.resultMetaChip}>
+            </button>
+            <button
+              type="button"
+              className={`${styles.resultMetaChip} ${
+                filterType === 'videos'
+                  ? styles.activeChip
+                  : filterType !== 'all'
+                    ? styles.dimmedChip
+                    : ''
+              }`}
+              onClick={() =>
+                setFilterType(filterType === 'videos' ? 'all' : 'videos')
+              }
+            >
+              {filterType === 'videos' && (
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className={styles.checkmarkIcon}
+                >
+                  <polyline points="10 3 4.5 8.5 2 6" />
+                </svg>
+              )}
               {t('globalSearchVideosCount', { count: filteredVideos.length })}
-            </span>
-            <span className={styles.resultMetaChipAccent}>
+            </button>
+            <button
+              type="button"
+              className={`${styles.resultMetaChipAccent} ${
+                filterType !== 'all' ? styles.clickableTotal : ''
+              }`}
+              onClick={() => setFilterType('all')}
+              disabled={filterType === 'all'}
+              title={
+                filterType !== 'all' ? t('filterPanel.resetFilters') : undefined
+              }
+            >
               {t('globalSearchTotal')}: {totalResults}
-            </span>
+            </button>
           </div>
         )}
       </header>
@@ -440,99 +511,103 @@ const GlobalSearchPage = () => {
         </section>
       ) : (
         <div className={styles.sections}>
-          <section className={styles.section}>
-            <div className={styles.sectionHeader}>
-              <div>
-                <p className={styles.sectionKicker}>{t('events')}</p>
-                <h2>
-                  {t('globalSearchEventsCount', {
-                    count: filteredEvents.length,
-                  })}
-                </h2>
+          {filterType !== 'videos' && (
+            <section className={styles.section}>
+              <div className={styles.sectionHeader}>
+                <div>
+                  <p className={styles.sectionKicker}>{t('events')}</p>
+                  <h2>
+                    {t('globalSearchEventsCount', {
+                      count: filteredEvents.length,
+                    })}
+                  </h2>
+                </div>
               </div>
-            </div>
 
-            {filteredEvents.length > 0 ? (
-              <div className={styles.eventGrid}>
-                {filteredEvents.map((event) => {
-                  const matchingTracks = getMatchingTracks(event, query);
+              {filteredEvents.length > 0 ? (
+                <div className={styles.eventGrid}>
+                  {filteredEvents.map((event) => {
+                    const matchingTracks = getMatchingTracks(event, query);
 
-                  return (
-                    <div className={styles.eventCard} key={event.id}>
-                      <EventBox
-                        event={event}
-                        eventStatus={EventStatus.Published}
-                        imageURL={eventMiniatures[event.id]}
-                      />
+                    return (
+                      <div className={styles.eventCard} key={event.id}>
+                        <EventBox
+                          event={event}
+                          eventStatus={EventStatus.Published}
+                          imageURL={eventMiniatures[event.id]}
+                        />
 
-                      {matchingTracks.length > 0 && (
-                        <div className={styles.trackMatches}>
-                          <span className={styles.trackMatchesLabel}>
-                            {t('globalSearchTrackMatches')}
-                          </span>
-                          <div className={styles.trackPills}>
-                            {matchingTracks.map((track) => (
-                              <span
-                                key={`${event.id}-${track}`}
-                                className={styles.trackPill}
-                              >
-                                {track}
-                              </span>
-                            ))}
+                        {matchingTracks.length > 0 && (
+                          <div className={styles.trackMatches}>
+                            <span className={styles.trackMatchesLabel}>
+                              {t('globalSearchTrackMatches')}
+                            </span>
+                            <div className={styles.trackPills}>
+                              {matchingTracks.map((track) => (
+                                <span
+                                  key={`${event.id}-${track}`}
+                                  className={styles.trackPill}
+                                >
+                                  {track}
+                                </span>
+                              ))}
+                            </div>
                           </div>
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className={styles.sectionEmpty}>
-                {t('globalSearchNoEvents')}
-              </div>
-            )}
-          </section>
-
-          <section className={styles.section}>
-            <div className={styles.sectionHeader}>
-              <div>
-                <p className={styles.sectionKicker}>{t('videos')}</p>
-                <h2>
-                  {t('globalSearchVideosCount', {
-                    count: filteredVideos.length,
+                        )}
+                      </div>
+                    );
                   })}
-                </h2>
-              </div>
-            </div>
+                </div>
+              ) : (
+                <div className={styles.sectionEmpty}>
+                  {t('globalSearchNoEvents')}
+                </div>
+              )}
+            </section>
+          )}
 
-            {filteredVideos.length > 0 ? (
-              <div className={styles.videoGrid}>
-                {filteredVideos.map((video) => (
-                  <div className={styles.videoCard} key={video.id}>
-                    <Thumbnail
-                      Id={video.id}
-                      title={video.title}
-                      creatorId={video.creator?.id || ''}
-                      createBy={
-                        video.creator?.username ||
-                        `${video.creator?.firstName ?? ''} ${video.creator?.lastName ?? ''}`.trim()
-                      }
-                      createdAt={video.createdAt.toString()}
-                      tags={video.tags
-                        ?.map((tag) => tag.name)
-                        .sort((a, b) => a.localeCompare(b))}
-                      cropTags={true}
-                      duration={video.duration}
-                    />
-                  </div>
-                ))}
+          {filterType !== 'events' && (
+            <section className={styles.section}>
+              <div className={styles.sectionHeader}>
+                <div>
+                  <p className={styles.sectionKicker}>{t('videos')}</p>
+                  <h2>
+                    {t('globalSearchVideosCount', {
+                      count: filteredVideos.length,
+                    })}
+                  </h2>
+                </div>
               </div>
-            ) : (
-              <div className={styles.sectionEmpty}>
-                {t('globalSearchNoVideos')}
-              </div>
-            )}
-          </section>
+
+              {filteredVideos.length > 0 ? (
+                <div className={styles.videoGrid}>
+                  {filteredVideos.map((video) => (
+                    <div className={styles.videoCard} key={video.id}>
+                      <Thumbnail
+                        Id={video.id}
+                        title={video.title}
+                        creatorId={video.creator?.id || ''}
+                        createBy={
+                          video.creator?.username ||
+                          `${video.creator?.firstName ?? ''} ${video.creator?.lastName ?? ''}`.trim()
+                        }
+                        createdAt={video.createdAt.toString()}
+                        tags={video.tags
+                          ?.map((tag) => tag.name)
+                          .sort((a, b) => a.localeCompare(b))}
+                        cropTags={true}
+                        duration={video.duration}
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className={styles.sectionEmpty}>
+                  {t('globalSearchNoVideos')}
+                </div>
+              )}
+            </section>
+          )}
         </div>
       )}
     </main>


### PR DESCRIPTION
## Describe your changes
* The search filters in the search results page are now clickable to see only the events, videos or both
* fix : The search filters in the global search bar were not showing in the UI when the url of the search was refreshed

