### PR TITLE
fix: align staging runtime with current view system

### DIFF
--- a/backend/src/videos/domain/usecases/createNewVideo.usecase.ts
+++ b/backend/src/videos/domain/usecases/createNewVideo.usecase.ts
@@ -2,7 +2,7 @@ import { CreateVideoDto } from '../../infra/controllers/dto/create-video.dto';
 import { IVideoGateway } from '../gateways/videos.gateway';
 import { VideoObject } from '../video';
 import { v4 as uuid } from 'uuid';
-import { Inject } from '@nestjs/common';
+import { BadRequestException, Inject } from '@nestjs/common';
 import { S3Client } from '@aws-sdk/client-s3';
 import { CommentEntity } from 'src/comments/infra/gateways/entities/comment.entity';
 import { Upload } from '@aws-sdk/lib-storage';
@@ -77,10 +77,15 @@ export class CreateNewVideoUsecase {
     await writeFile(tempInputPath, file.buffer);
 
     try {
-      // Extract video duration before transcoding
-      const videoDuration = await getVideoDuration(tempInputPath);
-      video.duration = videoDuration;
+      video.duration = await getVideoDuration(tempInputPath);
+    } catch {
+      await unlink(tempInputPath).catch(() => {});
+      throw new BadRequestException(
+        'Invalid video file: the uploaded media cannot be decoded',
+      );
+    }
 
+    try {
       await transcodeVideo(tempInputPath, tempOutputPath);
 
       mediaBuffer = await readFile(tempOutputPath);

--- a/backend/tests/events/domain/usecases/miniatureFormat.usecase.spec.ts
+++ b/backend/tests/events/domain/usecases/miniatureFormat.usecase.spec.ts
@@ -9,6 +9,7 @@ import { VideoObject } from 'src/videos/domain/video';
 import { TagEntity } from 'src/tags/infra/gateways/entities/tag.entity';
 import { UserEntity } from 'src/users/infra/gateways/entities/user.entity';
 import * as sharp from 'sharp';
+import * as ffmpeg from 'fluent-ffmpeg';
 
 jest.mock('@aws-sdk/lib-storage', () => ({
   Upload: jest.fn().mockImplementation(() => ({
@@ -80,6 +81,8 @@ describe('CreateNewVideoUsecase - Miniature Processing', () => {
   let s3Client: S3Client;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CreateNewVideoUsecase,
@@ -93,6 +96,39 @@ describe('CreateNewVideoUsecase - Miniature Processing', () => {
     );
     videoGateway = module.get<IVideoGateway>('VideoGateway');
     s3Client = module.get<S3Client>('s3Client');
+  });
+
+  it('should reject an invalid video before uploading it', async () => {
+    const dto: CreateVideoDto = {
+      title: 'Invalid Video',
+      description: 'An invalid video file',
+      tags: [new TagEntity({ name: 'test' })],
+      creator: new UserEntity({ id: 'creatorId', firstName: 'Creator Name' }),
+      media_id: 'invalid.mp4',
+      miniature_id: 'test-miniature',
+      internal_speakers: [],
+      external_speakers: '',
+      comments: [],
+      archived: false,
+    };
+
+    (ffmpeg.ffprobe as jest.Mock).mockImplementationOnce(
+      (_inputPath, callback) => callback(new Error('Invalid media')),
+    );
+
+    await expect(
+      createNewVideoUsecase.execute(
+        dto,
+        { buffer: Buffer.alloc(1024) } as Express.Multer.File,
+        undefined,
+      ),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: 'Invalid video file: the uploaded media cannot be decoded',
+    });
+
+    expect(Upload).not.toHaveBeenCalled();
+    expect(videoGateway.createNewVideo).not.toHaveBeenCalled();
   });
 
   it('should resize the video miniature to 1280x720 and upload it to S3', async () => {

--- a/frontend/src/context/UploadContext.tsx
+++ b/frontend/src/context/UploadContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
+import getEnv from '../utils/env';
 
 export type UploadStatus =
   | 'pending'
@@ -154,7 +155,7 @@ export function UploadProvider({ children }: { children: ReactNode }) {
         // Vérifier chaque vidéo en processing de manière asynchrone
         processingUploads.forEach(async (upload) => {
           try {
-            const baseUrl = `${process.env.REACT_APP_API_URL}:${process.env.REACT_APP_API_PORT}/api`;
+            const baseUrl = `${getEnv('REACT_APP_API_URL')}:${getEnv('REACT_APP_API_PORT')}/api`;
             const userString = localStorage.getItem('backendUser');
             const user = userString ? JSON.parse(userString) : null;
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -172,7 +172,7 @@ export const getTrackChatStatistics = (trackId) =>
 // SFU viewer count
 export const getRoomViewerCount = async (roomId) => {
   const sfuUrl =
-    process.env.REACT_APP_SFU_CONTROL_PLANE_URL || 'http://localhost:8090';
+    getEnv('REACT_APP_SFU_CONTROL_PLANE_URL') || 'http://localhost:8090';
   try {
     const response = await fetch(`${sfuUrl}/room/viewers?room_id=${roomId}`);
     if (!response.ok) {

--- a/frontend/src/utils/uploadService.ts
+++ b/frontend/src/utils/uploadService.ts
@@ -3,6 +3,8 @@
  * Utilise XMLHttpRequest pour permettre le tracking de la progression
  */
 
+import getEnv from './env';
+
 export interface UploadProgressCallback {
   onProgress: (progress: number) => void;
   onComplete: (response: { id: string }) => void;
@@ -20,7 +22,7 @@ export function uploadVideoWithProgress(
   callbacks: UploadProgressCallback,
 ): () => void {
   const xhr = new XMLHttpRequest();
-  const baseUrl = `${process.env.REACT_APP_API_URL}:${process.env.REACT_APP_API_PORT}/api`;
+  const baseUrl = `${getEnv('REACT_APP_API_URL')}:${getEnv('REACT_APP_API_PORT')}/api`;
 
   // Récupérer le token d'authentification
   const userString = localStorage.getItem('backendUser');


### PR DESCRIPTION
## Summary
- keep the current `main` view-count implementation used by staging
- use runtime-injected frontend URLs for uploads and SFU calls
- reject invalid video uploads before writing them to object storage

This combines the fixes needed by the staging images deployed in ops commit `d1de93c`. It supersedes the narrower backend-only PR #137.

## Verification
- backend build
- backend tests: 152 passed
- frontend production build
- staging `POST /api/videos/:id/views`: verified `views` changed from 0 to 1
