### PR TITLE
feat(sfu): frontend & operator UX for on-demand autoscaling [6.1–6.4]

### DIFF
--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -263,6 +263,8 @@
   "CopyURL": "Copy URL",
   "URLCopied": "URL copied to clipboard!",
   "RoomCreatedSuccessfully": "Room created successfully! URL is now available below.",
+  "RoomProvisioningTitle": "Preparing streaming server",
+  "RoomProvisioningDescription": "Your live room is being prepared. The OBS URL will appear when the server is ready.",
   "ErrorCreatingRoom": "Error creating room. Please try again.",
   "QRCodeDownloaded": "QR code downloaded successfully",
   "QRCodeDownloadError": "Error downloading QR code",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -265,6 +265,8 @@
   "RoomCreatedSuccessfully": "Room created successfully! URL is now available below.",
   "RoomProvisioningTitle": "Preparing streaming server",
   "RoomProvisioningDescription": "Your live room is being prepared. The OBS URL will appear when the server is ready.",
+  "RoomProvisioningFailedTitle": "Streaming server unavailable",
+  "RoomProvisioningFailedDescription": "The live server could not be prepared. Try again later or contact an operator.",
   "ErrorCreatingRoom": "Error creating room. Please try again.",
   "QRCodeDownloaded": "QR code downloaded successfully",
   "QRCodeDownloadError": "Error downloading QR code",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -263,6 +263,8 @@
   "CopyURL": "Copier l'URL",
   "URLCopied": "URL copiée dans le presse-papier !",
   "RoomCreatedSuccessfully": "Salle créée avec succès ! L'URL est maintenant disponible ci-dessous.",
+  "RoomProvisioningTitle": "Préparation du serveur live",
+  "RoomProvisioningDescription": "La salle live est en cours de préparation. L'URL OBS apparaîtra quand le serveur sera prêt.",
   "ErrorCreatingRoom": "Erreur lors de la création de la salle. Veuillez réessayer.",
   "QRCodeDownloaded": "Code QR téléchargé avec succès",
   "QRCodeDownloadError": "Erreur lors du téléchargement du code QR",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -265,6 +265,8 @@
   "RoomCreatedSuccessfully": "Salle créée avec succès ! L'URL est maintenant disponible ci-dessous.",
   "RoomProvisioningTitle": "Préparation du serveur live",
   "RoomProvisioningDescription": "La salle live est en cours de préparation. L'URL OBS apparaîtra quand le serveur sera prêt.",
+  "RoomProvisioningFailedTitle": "Serveur live indisponible",
+  "RoomProvisioningFailedDescription": "Le serveur live n'a pas pu être préparé. Réessayez plus tard ou contactez un opérateur.",
   "ErrorCreatingRoom": "Erreur lors de la création de la salle. Veuillez réessayer.",
   "QRCodeDownloaded": "Code QR téléchargé avec succès",
   "QRCodeDownloadError": "Erreur lors du téléchargement du code QR",

--- a/frontend/src/pages/trackSettings/trackSettings.module.css
+++ b/frontend/src/pages/trackSettings/trackSettings.module.css
@@ -130,7 +130,7 @@
   border-radius: 8px;
 }
 
-.trackDateSpeakerWrapper>h3 {
+.trackDateSpeakerWrapper > h3 {
   color: var(--theme-color-900, #1a1a1a);
   font-size: 1.1rem;
   margin: 0 0 0.5rem 0;
@@ -255,6 +255,12 @@
   margin: 0;
   font-size: 0.9rem;
   line-height: 1.45;
+}
+
+.roomStatusFailed {
+  border-color: #fecaca;
+  background-color: #fef2f2;
+  color: #991b1b;
 }
 
 /* ===== QR CODE SECTION ===== */

--- a/frontend/src/pages/trackSettings/trackSettings.module.css
+++ b/frontend/src/pages/trackSettings/trackSettings.module.css
@@ -235,6 +235,28 @@
   font-size: 0.9rem;
 }
 
+.roomStatus {
+  width: 100%;
+  padding: 1rem;
+  border: 1px solid var(--theme-color-100, #e0e0e0);
+  border-radius: 8px;
+  background-color: var(--theme-color-50, #f9fafb);
+  color: var(--theme-color-1050);
+}
+
+.roomStatus strong {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.roomStatus p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
 /* ===== QR CODE SECTION ===== */
 .mainContentWrapper {
   display: flex;

--- a/frontend/src/pages/trackSettings/trackSettings.tsx
+++ b/frontend/src/pages/trackSettings/trackSettings.tsx
@@ -28,6 +28,40 @@ import { closeTrack, startRecording, stopRecording } from '../../utils/api';
 import styles from './trackSettings.module.css';
 import getEnv from '../../utils/env';
 const CONTROL_PLANE_URL = getEnv('REACT_APP_SFU_CONTROL_PLANE_URL');
+const ROOM_STATUS_POLL_INTERVAL_MS = 3000;
+const ROOM_STATUS_TIMEOUT_MS = 8 * 60 * 1000;
+
+type RoomLifecycleState =
+  | 'provisioning'
+  | 'ready'
+  | 'failed'
+  | 'draining'
+  | 'terminated';
+
+type RoomStatusResponse = {
+  exists?: boolean;
+  room_id?: string;
+  state?: RoomLifecycleState;
+  ready?: boolean;
+  reason?: string;
+  whip_url?: string;
+};
+
+type CreateRoomResponse = {
+  room_id: string;
+  key: string;
+  state?: RoomLifecycleState;
+  ready?: boolean;
+  message?: string;
+};
+
+const buildWhipUrl = (roomId: string, roomKey: string) =>
+  `${CONTROL_PLANE_URL}/whip?room_id=${encodeURIComponent(
+    roomId,
+  )}&key=${encodeURIComponent(roomKey)}`;
+
+const sleep = (durationMs: number) =>
+  new Promise((resolve) => window.setTimeout(resolve, durationMs));
 
 const TrackSettings: FC = () => {
   const { trackId, eventId } = useParams();
@@ -53,6 +87,9 @@ const TrackSettings: FC = () => {
   const [sfuUrl, setSfuUrl] = useState<string>('');
   const [isLoadingSfu, setIsLoadingSfu] = useState(false);
   const [isCheckingRoom, setIsCheckingRoom] = useState(false);
+  const [roomLifecycleState, setRoomLifecycleState] =
+    useState<RoomLifecycleState | null>(null);
+  const [roomStatusMessage, setRoomStatusMessage] = useState('');
   const [touched, setTouched] = useState({ name: false, description: false });
   const [toast, setToast] = useState<{
     message: string;
@@ -66,11 +103,95 @@ const TrackSettings: FC = () => {
 
   const qrCodeRef = useRef<HTMLDivElement>(null);
 
+  const fetchRoomStatus = useCallback(async (roomId: string) => {
+    try {
+      const response = await fetch(
+        `${CONTROL_PLANE_URL}/room/status?room_id=${encodeURIComponent(
+          roomId,
+        )}`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+
+      if (!response.ok) {
+        return null;
+      }
+
+      return (await response.json()) as RoomStatusResponse;
+    } catch (error) {
+      console.error('Error fetching room status:', error);
+      return null;
+    }
+  }, []);
+
+  const waitForRoomReady = useCallback(
+    async (roomId: string, roomKey: string) => {
+      const deadline = Date.now() + ROOM_STATUS_TIMEOUT_MS;
+
+      while (Date.now() < deadline) {
+        const status = await fetchRoomStatus(roomId);
+        const state = status?.state;
+
+        if (state) {
+          setRoomLifecycleState(state);
+        }
+
+        if (status?.ready || state === 'ready') {
+          setRoomStatusMessage('');
+          return buildWhipUrl(roomId, roomKey);
+        }
+
+        if (state === 'failed' || state === 'terminated') {
+          throw new Error(status?.reason || 'Room provisioning failed');
+        }
+
+        setRoomLifecycleState(state || 'provisioning');
+        setRoomStatusMessage(t('RoomProvisioningDescription'));
+        await sleep(ROOM_STATUS_POLL_INTERVAL_MS);
+      }
+
+      throw new Error('Room provisioning timed out');
+    },
+    [fetchRoomStatus, t],
+  );
+
   const checkRoomExists = useCallback(async () => {
     if (!trackId) return;
 
     setIsCheckingRoom(true);
     try {
+      const status = await fetchRoomStatus(trackId);
+      if (status?.state === 'failed' || status?.state === 'terminated') {
+        setRoomLifecycleState(status.state);
+        setRoomStatusMessage(status.reason || '');
+        setSfuUrl('');
+        return;
+      }
+
+      if (
+        status?.state === 'provisioning' ||
+        status?.state === 'draining' ||
+        status?.ready === false
+      ) {
+        setRoomLifecycleState(status.state || 'provisioning');
+        setRoomStatusMessage(t('RoomProvisioningDescription'));
+        setSfuUrl('');
+        return;
+      }
+
+      if (status?.ready || status?.state === 'ready') {
+        setRoomLifecycleState('ready');
+        setRoomStatusMessage('');
+        if (status.whip_url) {
+          setSfuUrl(status.whip_url);
+          return;
+        }
+      }
+
       const response = await fetch(
         `${CONTROL_PLANE_URL}/room/exists?room_id=${trackId}`,
         {
@@ -87,17 +208,23 @@ const TrackSettings: FC = () => {
 
       const data = await response.json();
       if (data.exists && data.whip_url) {
+        setRoomLifecycleState('ready');
+        setRoomStatusMessage('');
         setSfuUrl(data.whip_url);
       } else {
+        setRoomLifecycleState(null);
+        setRoomStatusMessage('');
         setSfuUrl('');
       }
     } catch (error) {
       console.error('Error checking room:', error);
+      setRoomLifecycleState(null);
+      setRoomStatusMessage('');
       setSfuUrl('');
     } finally {
       setIsCheckingRoom(false);
     }
-  }, [trackId]);
+  }, [fetchRoomStatus, t, trackId]);
 
   useEffect(() => {
     if (trackId) {
@@ -177,6 +304,9 @@ const TrackSettings: FC = () => {
     if (!trackId) return;
 
     setIsLoadingSfu(true);
+    setSfuUrl('');
+    setRoomLifecycleState('provisioning');
+    setRoomStatusMessage(t('RoomProvisioningDescription'));
     try {
       const response = await fetch(`${CONTROL_PLANE_URL}/room/create`, {
         method: 'POST',
@@ -192,12 +322,22 @@ const TrackSettings: FC = () => {
         throw new Error('Failed to create room');
       }
 
-      const data = await response.json();
+      const data = (await response.json()) as CreateRoomResponse;
       // Store room info for recording
       setSfuRoomId(data.room_id);
       setSfuRoomKey(data.key);
-      const whipUrl = `${CONTROL_PLANE_URL}/whip?room_id=${data.room_id}&key=${data.key}`;
+
+      const state = data.state || (data.ready ? 'ready' : 'provisioning');
+      setRoomLifecycleState(state);
+
+      const whipUrl =
+        state === 'ready' || data.ready
+          ? buildWhipUrl(data.room_id, data.key)
+          : await waitForRoomReady(data.room_id, data.key);
+
       setSfuUrl(whipUrl);
+      setRoomLifecycleState('ready');
+      setRoomStatusMessage('');
       setIsOpen(false);
       setToast({
         message: t('RoomCreatedSuccessfully'),
@@ -205,6 +345,7 @@ const TrackSettings: FC = () => {
       });
     } catch (error) {
       console.error('Error creating SFU room:', error);
+      setRoomStatusMessage('');
       setToast({
         message: t('ErrorCreatingRoom'),
         type: 'error',
@@ -641,6 +782,12 @@ const TrackSettings: FC = () => {
             {isCheckingRoom && (
               <div className={styles.roomStatus}>
                 <p>{t('CheckingRoom') || 'Checking room status...'}</p>
+              </div>
+            )}
+            {roomLifecycleState === 'provisioning' && (
+              <div className={styles.roomStatus}>
+                <strong>{t('RoomProvisioningTitle')}</strong>
+                <p>{roomStatusMessage || t('RoomProvisioningDescription')}</p>
               </div>
             )}
             {sfuUrl && (

--- a/frontend/src/pages/trackSettings/trackSettings.tsx
+++ b/frontend/src/pages/trackSettings/trackSettings.tsx
@@ -32,11 +32,7 @@ const ROOM_STATUS_POLL_INTERVAL_MS = 3000;
 const ROOM_STATUS_TIMEOUT_MS = 8 * 60 * 1000;
 
 type RoomLifecycleState =
-  | 'provisioning'
-  | 'ready'
-  | 'failed'
-  | 'draining'
-  | 'terminated';
+  'provisioning' | 'ready' | 'failed' | 'draining' | 'terminated';
 
 type RoomStatusResponse = {
   exists?: boolean;
@@ -62,6 +58,9 @@ const buildWhipUrl = (roomId: string, roomKey: string) =>
 
 const sleep = (durationMs: number) =>
   new Promise((resolve) => window.setTimeout(resolve, durationMs));
+
+const getErrorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error && error.message ? error.message : fallback;
 
 const TrackSettings: FC = () => {
   const { trackId, eventId } = useParams();
@@ -146,7 +145,9 @@ const TrackSettings: FC = () => {
         }
 
         if (state === 'failed' || state === 'terminated') {
-          throw new Error(status?.reason || 'Room provisioning failed');
+          throw new Error(
+            status?.reason || t('RoomProvisioningFailedDescription'),
+          );
         }
 
         setRoomLifecycleState(state || 'provisioning');
@@ -154,7 +155,7 @@ const TrackSettings: FC = () => {
         await sleep(ROOM_STATUS_POLL_INTERVAL_MS);
       }
 
-      throw new Error('Room provisioning timed out');
+      throw new Error(t('RoomProvisioningFailedDescription'));
     },
     [fetchRoomStatus, t],
   );
@@ -167,7 +168,9 @@ const TrackSettings: FC = () => {
       const status = await fetchRoomStatus(trackId);
       if (status?.state === 'failed' || status?.state === 'terminated') {
         setRoomLifecycleState(status.state);
-        setRoomStatusMessage(status.reason || '');
+        setRoomStatusMessage(
+          status.reason || t('RoomProvisioningFailedDescription'),
+        );
         setSfuUrl('');
         return;
       }
@@ -345,9 +348,12 @@ const TrackSettings: FC = () => {
       });
     } catch (error) {
       console.error('Error creating SFU room:', error);
-      setRoomStatusMessage('');
+      setRoomLifecycleState('failed');
+      setRoomStatusMessage(
+        getErrorMessage(error, t('RoomProvisioningFailedDescription')),
+      );
       setToast({
-        message: t('ErrorCreatingRoom'),
+        message: t('RoomProvisioningFailedTitle'),
         type: 'error',
       });
     } finally {
@@ -788,6 +794,17 @@ const TrackSettings: FC = () => {
               <div className={styles.roomStatus}>
                 <strong>{t('RoomProvisioningTitle')}</strong>
                 <p>{roomStatusMessage || t('RoomProvisioningDescription')}</p>
+              </div>
+            )}
+            {(roomLifecycleState === 'failed' ||
+              roomLifecycleState === 'terminated') && (
+              <div
+                className={`${styles.roomStatus} ${styles.roomStatusFailed}`}
+              >
+                <strong>{t('RoomProvisioningFailedTitle')}</strong>
+                <p>
+                  {roomStatusMessage || t('RoomProvisioningFailedDescription')}
+                </p>
               </div>
             )}
             {sfuUrl && (

--- a/sfuServer/cmd/controlplane/main.go
+++ b/sfuServer/cmd/controlplane/main.go
@@ -39,6 +39,7 @@ func main() {
 	http.HandleFunc("/control/join_host", corsMiddleware(cp.HandleJoinHost))
 	http.HandleFunc("/control/join_viewer", corsMiddleware(cp.HandleJoinViewer))
 	http.HandleFunc("/control/topology", corsMiddleware(cp.HandleGetTopology))
+	http.HandleFunc("/control/operator_status", corsMiddleware(cp.HandleOperatorStatus))
 	http.HandleFunc("/room/create", corsMiddleware(cp.HandleCreateRoom))
 	http.HandleFunc("/room/exists", corsMiddleware(cp.HandleRoomExists))
 	http.HandleFunc("/room/status", corsMiddleware(cp.HandleRoomStatus)) // Poll provisioning -> ready/failed

--- a/sfuServer/pkg/controlplane/controlplane.go
+++ b/sfuServer/pkg/controlplane/controlplane.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"sort"
 	"sync"
 	"time"
 
@@ -133,6 +134,44 @@ type SFUInfo struct {
 	Metrics       *models.SFUMetrics
 	LastHeartbeat time.Time
 	Active        bool
+}
+
+type operatorSFUStatus struct {
+	ID            string    `json:"id"`
+	URL           string    `json:"url"`
+	Region        string    `json:"region,omitempty"`
+	Zone          string    `json:"zone,omitempty"`
+	Active        bool      `json:"active"`
+	LastHeartbeat time.Time `json:"last_heartbeat"`
+	CPU           float64   `json:"cpu,omitempty"`
+	Memory        float64   `json:"memory,omitempty"`
+	ActiveHosts   int       `json:"active_hosts,omitempty"`
+	ActiveViewers int       `json:"active_viewers,omitempty"`
+}
+
+type operatorFailureStatus struct {
+	Kind   string `json:"kind"`
+	ID     string `json:"id"`
+	State  string `json:"state"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type operatorStatusCounts struct {
+	RegisteredSFUs int                        `json:"registered_sfus"`
+	ActiveSFUs     int                        `json:"active_sfus"`
+	RoomsByState   map[models.RoomState]int   `json:"rooms_by_state"`
+	WorkersByState map[models.WorkerState]int `json:"workers_by_state"`
+}
+
+type operatorStatusResponse struct {
+	GeneratedAt             time.Time               `json:"generated_at"`
+	LifecycleStoreAvailable bool                    `json:"lifecycle_store_available"`
+	Counts                  operatorStatusCounts    `json:"counts"`
+	RegisteredSFUs          []operatorSFUStatus     `json:"registered_sfus"`
+	Rooms                   []models.RoomLifecycle  `json:"rooms"`
+	Workers                 []models.WorkerRecord   `json:"workers"`
+	ProvisioningFailures    []operatorFailureStatus `json:"provisioning_failures"`
+	PendingCleanupRooms     []string                `json:"pending_cleanup_rooms"`
 }
 
 // NewControlPlane creates a new control plane instance
@@ -2093,6 +2132,124 @@ func (cp *ControlPlane) HandleRoomExists(w http.ResponseWriter, r *http.Request)
 		"whip_url": whipURL,
 	})
 	log.Printf("[CP-EXISTS] Room %s exists", roomID)
+}
+
+func (cp *ControlPlane) operatorStatus() operatorStatusResponse {
+	now := time.Now().UTC()
+
+	cp.mu.RLock()
+	registeredSFUs := make([]operatorSFUStatus, 0, len(cp.sfus))
+	activeSFUs := 0
+	for _, sfu := range cp.sfus {
+		status := operatorSFUStatus{
+			ID:            sfu.ID,
+			URL:           sfu.URL,
+			Region:        sfu.Region,
+			Zone:          sfu.Zone,
+			Active:        sfu.Active,
+			LastHeartbeat: sfu.LastHeartbeat,
+		}
+		if sfu.Active {
+			activeSFUs++
+		}
+		if sfu.Metrics != nil {
+			status.CPU = sfu.Metrics.CPU
+			status.Memory = sfu.Metrics.Memory
+			status.ActiveHosts = sfu.Metrics.ActiveHosts
+			status.ActiveViewers = sfu.Metrics.ActiveViewers
+		}
+		registeredSFUs = append(registeredSFUs, status)
+	}
+	cp.mu.RUnlock()
+
+	sort.Slice(registeredSFUs, func(i, j int) bool {
+		return registeredSFUs[i].ID < registeredSFUs[j].ID
+	})
+
+	cp.cleanupMu.Lock()
+	pendingCleanupRooms := make([]string, 0, len(cp.pendingCleanups))
+	for roomID := range cp.pendingCleanups {
+		pendingCleanupRooms = append(pendingCleanupRooms, roomID)
+	}
+	cp.cleanupMu.Unlock()
+	sort.Strings(pendingCleanupRooms)
+
+	var rooms []models.RoomLifecycle
+	var workers []models.WorkerRecord
+	lifecycleStoreAvailable := cp.roomState != nil
+	if cp.roomState != nil {
+		rooms = cp.roomState.List()
+		workers = cp.roomState.ListWorkers()
+	}
+
+	sort.Slice(rooms, func(i, j int) bool {
+		return rooms[i].RoomID < rooms[j].RoomID
+	})
+	sort.Slice(workers, func(i, j int) bool {
+		return workers[i].SFUID < workers[j].SFUID
+	})
+
+	roomsByState := make(map[models.RoomState]int)
+	workersByState := make(map[models.WorkerState]int)
+	failures := make([]operatorFailureStatus, 0)
+
+	for _, room := range rooms {
+		roomsByState[room.State]++
+		if room.State == models.RoomFailed {
+			failures = append(failures, operatorFailureStatus{
+				Kind:   "room",
+				ID:     room.RoomID,
+				State:  string(room.State),
+				Reason: room.Reason,
+			})
+		}
+	}
+	for _, worker := range workers {
+		workersByState[worker.State]++
+		if worker.State == models.WorkerFailed {
+			failures = append(failures, operatorFailureStatus{
+				Kind:   "worker",
+				ID:     worker.SFUID,
+				State:  string(worker.State),
+				Reason: worker.Reason,
+			})
+		}
+	}
+
+	sort.Slice(failures, func(i, j int) bool {
+		if failures[i].Kind == failures[j].Kind {
+			return failures[i].ID < failures[j].ID
+		}
+		return failures[i].Kind < failures[j].Kind
+	})
+
+	return operatorStatusResponse{
+		GeneratedAt:             now,
+		LifecycleStoreAvailable: lifecycleStoreAvailable,
+		Counts: operatorStatusCounts{
+			RegisteredSFUs: len(registeredSFUs),
+			ActiveSFUs:     activeSFUs,
+			RoomsByState:   roomsByState,
+			WorkersByState: workersByState,
+		},
+		RegisteredSFUs:       registeredSFUs,
+		Rooms:                rooms,
+		Workers:              workers,
+		ProvisioningFailures: failures,
+		PendingCleanupRooms:  pendingCleanupRooms,
+	}
+}
+
+// HandleOperatorStatus exposes a compact operational snapshot for active SFUs,
+// worker lifecycle, provisioning failures, and scheduled cleanup actions.
+func (cp *ControlPlane) HandleOperatorStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Only GET is supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(cp.operatorStatus())
 }
 
 // HandleRoomStatus reports a room's lifecycle state so a streamer can poll a

--- a/sfuServer/pkg/controlplane/controlplane_test.go
+++ b/sfuServer/pkg/controlplane/controlplane_test.go
@@ -283,3 +283,76 @@ func TestColdStartProvisionFailureMarksRoomFailed(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+func TestOperatorStatusReportsWorkersFailuresAndCleanup(t *testing.T) {
+	cp := newTestCP(t)
+
+	if err := cp.RegisterSFU(&models.SFURegistration{SFUID: "sfu-active", ServerURL: "http://sfu-active"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cp.UpdateMetrics(&models.SFUMetrics{
+		SFUID:         "sfu-active",
+		ServerURL:     "http://sfu-active",
+		CPU:           0.2,
+		Memory:        0.3,
+		ActiveHosts:   1,
+		ActiveViewers: 3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := cp.roomState.Upsert("room-failed", models.RoomFailed, "budget exceeded"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cp.roomState.Upsert("room-ready", models.RoomReady, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cp.roomState.UpsertWorker(models.WorkerRecord{
+		SFUID:  "sfu-failed",
+		State:  models.WorkerFailed,
+		RoomID: "room-failed",
+		Reason: "startup timeout",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cp.roomState.UpsertWorker(models.WorkerRecord{
+		SFUID:  "sfu-ready",
+		State:  models.WorkerReady,
+		RoomID: "room-ready",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+	cp.cleanupMu.Lock()
+	cp.pendingCleanups["room-cleanup"] = timer
+	cp.cleanupMu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/control/operator_status", nil)
+	rec := httptest.NewRecorder()
+	cp.HandleOperatorStatus(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", rec.Code)
+	}
+
+	var body operatorStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode operator status: %v", err)
+	}
+	if body.Counts.RegisteredSFUs != 1 || body.Counts.ActiveSFUs != 1 {
+		t.Fatalf("sfu counts = %+v, want one registered and active", body.Counts)
+	}
+	if body.Counts.RoomsByState[models.RoomFailed] != 1 {
+		t.Fatalf("failed room count = %d, want 1", body.Counts.RoomsByState[models.RoomFailed])
+	}
+	if body.Counts.WorkersByState[models.WorkerFailed] != 1 {
+		t.Fatalf("failed worker count = %d, want 1", body.Counts.WorkersByState[models.WorkerFailed])
+	}
+	if len(body.ProvisioningFailures) != 2 {
+		t.Fatalf("failures = %+v, want room and worker failure", body.ProvisioningFailures)
+	}
+	if len(body.PendingCleanupRooms) != 1 || body.PendingCleanupRooms[0] != "room-cleanup" {
+		t.Fatalf("pending cleanup rooms = %+v, want room-cleanup", body.PendingCleanupRooms)
+	}
+}


### PR DESCRIPTION
Covers **Section 6 (Frontend and Operator UX)** of the `add-on-demand-sfu-autoscaling` OpenSpec change.

> **Stacked on #149.** Base is `4.1-provider-adapter`; GitHub will retarget this to `main` automatically once #149 merges. Review #149 first.

### Tasks

| Task | Commit |
|---|---|
| 6.1 show "server preparing" during provisioning | `62a27f4` |
| 6.2 hide WHIP instructions until ready | `62a27f4` |
| 6.3 controlled failure state (provisioning fail / budget cap) | `950650e` |
| 6.4 operator-visible status for workers, failures, cleanup | `ec9046e` |

### Why this is a separate, small PR

Section 6 previously lived on `feat/6-frontend-operator-ux`, which carried a **duplicate copy of the entire 3.1→5.5 stack** under different hashes (18 commits total, on an older base). Rebasing onto the rebased stack drops the 15 patch-equivalent duplicates, leaving exactly these 3 commits — so this PR needs no branch-per-part exception.

Worth flagging: merging #149 alone would have landed 3.1→5.5 while silently dropping Section 6, even though `tasks.md` marks 6.1–6.4 done. Both PRs must land.

### Verification

```
go build ./...                    clean
go test -count=1 ./...            ok — autoscaler, lifecycle, provider, controlplane
react-scripts build (frontend)    compiled successfully
```

Notes:
- The frontend has **no test suite** (0 of 138 files match `testMatch`) — pre-existing; the type-checked production build is the effective gate.
- `npm run lint` (backend) is **broken on `main` as well**: `.eslintignore` causes ESLint to exit 2 with "all of the files matching the glob pattern are ignored". Pre-existing, unrelated to this change, not fixed here.

### After both PRs land

These branches point into superseded lineages and should be deleted so nobody merges the wrong copy: `feat/6-frontend-operator-ux`, `3.1-room-lifecycle-state`, `3.2-worker-records`, `3.3-idempotent-lookup`. (Keep `feat/sfu-autoscaler` — unrelated dry-run burst autoscaler.)
