### PR TITLE
feat(sfu): inject worker bootstrap through cloud-init

### DIFF
--- a/sfuServer/.env.example
+++ b/sfuServer/.env.example
@@ -82,6 +82,15 @@ CASCADE_AUTH_KEY=your-secure-cascade-key-here
 # Do not commit real TURN credentials. Inject them from secrets/runtime values.
 # TURN_PASSWORD=password
 
+# Public TLS URL used by ephemeral workers to register with this control-plane.
+# SFU_CONTROL_PLANE_URL=https://sfu-staging.example.com
+
+# Immutable worker image and optional private registry credentials.
+# SFU_IMAGE_TAG=sha-0123456789ab
+# SFU_REGISTRY=rg.fr-par.scw.cloud/sfu-server
+# SFU_REGISTRY_USERNAME=your-registry-user
+# SFU_REGISTRY_PASSWORD=your-registry-password
+
 # Public IP (for NAT1To1 mapping)
 # Use this if running in Docker/container with port mapping
 # This IP will be advertised as the host candidate to WebRTC clients

--- a/sfuServer/cmd/controlplane/main.go
+++ b/sfuServer/cmd/controlplane/main.go
@@ -7,8 +7,10 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
+	bootstrap "whip-server/deploy"
 	"whip-server/internal/autoscaler"
 	"whip-server/internal/provider/scaleway"
 	"whip-server/pkg/controlplane"
@@ -117,14 +119,35 @@ func wireAutoscaler(cp *controlplane.ControlPlane) error {
 		return err
 	}
 
+	workerBootstrap := bootstrap.WorkerConfig{
+		ImageTag:        os.Getenv("SFU_IMAGE_TAG"),
+		ControlPlaneURL: firstNonEmpty(os.Getenv("SFU_CONTROL_PLANE_URL"), os.Getenv("CONTROL_PLANE_URL")),
+		Registry:        os.Getenv("SFU_REGISTRY"),
+		RegistryUser:    os.Getenv("SFU_REGISTRY_USERNAME"),
+		RegistryPass:    os.Getenv("SFU_REGISTRY_PASSWORD"),
+		SFUPort:         getEnv("SFU_WORKER_PORT", "8090"),
+		ICERelayOnly:    envBool("ICE_RELAY_ONLY", true),
+		EnableICETCP:    envBool("ENABLE_ICE_TCP", false),
+		STUNServers:     os.Getenv("STUN_SERVERS"),
+		TURNServer:      os.Getenv("TURN_SERVER"),
+		TURNUsername:    os.Getenv("TURN_USERNAME"),
+		TURNPassword:    os.Getenv("TURN_PASSWORD"),
+	}
+	if err := workerBootstrap.Validate(); err != nil {
+		return fmt.Errorf("worker bootstrap config: %w", err)
+	}
+
 	maxWorkers := 1
 	if v, err := strconv.Atoi(os.Getenv("SFU_MAX_WORKERS")); err == nil && v > 0 {
 		maxWorkers = v
 	}
 	prov := autoscaler.New(store, adapter, autoscaler.Config{
 		MaxWorkers: maxWorkers,
-		ImageTag:   os.Getenv("SFU_IMAGE_TAG"),
+		ImageTag:   workerBootstrap.ImageTag,
 		ManagedTag: getEnv("SFU_MANAGED_TAG", "sfu-worker"),
+		RenderUserData: func(sfuID, roomID string) string {
+			return workerBootstrap.Render(sfuID, roomID)
+		},
 	})
 	cp.SetProvisioner(prov)
 
@@ -134,6 +157,27 @@ func wireAutoscaler(cp *controlplane.ControlPlane) error {
 
 	log.Printf("[CP] on-demand SFU autoscaler enabled (max_workers=%d)", maxWorkers)
 	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func envBool(key string, defaultValue bool) bool {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
 }
 
 // janitor periodically reconciles worker records against the cloud and cleans up

--- a/sfuServer/deploy/bootstrap.go
+++ b/sfuServer/deploy/bootstrap.go
@@ -1,0 +1,104 @@
+package bootstrap
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+)
+
+const defaultRegistry = "rg.fr-par.scw.cloud/sfu-server"
+
+//go:embed scaleway-worker-bootstrap.sh
+var workerBootstrapScript string
+
+// WorkerConfig contains the values injected into a newly created SFU worker.
+// Sensitive values are read by the control-plane from its Kubernetes Secret
+// and are only copied into the cloud-init payload for the worker being created.
+type WorkerConfig struct {
+	ImageTag        string
+	ControlPlaneURL string
+	Registry        string
+	RegistryUser    string
+	RegistryPass    string
+	SFUPort         string
+	ICERelayOnly    bool
+	EnableICETCP    bool
+	STUNServers     string
+	TURNServer      string
+	TURNUsername    string
+	TURNPassword    string
+}
+
+// Validate fails closed before the autoscaler is enabled. This prevents it
+// from creating an Instance that cannot bootstrap and would only be reaped
+// after the startup timeout.
+func (c WorkerConfig) Validate() error {
+	if c.ImageTag == "" {
+		return fmt.Errorf("SFU_IMAGE_TAG must be set")
+	}
+	if c.ImageTag == "latest" {
+		return fmt.Errorf("SFU_IMAGE_TAG must be immutable, got latest")
+	}
+	if c.ControlPlaneURL == "" {
+		return fmt.Errorf("SFU_CONTROL_PLANE_URL must be set")
+	}
+	if (c.RegistryUser == "") != (c.RegistryPass == "") {
+		return fmt.Errorf("SFU_REGISTRY_USERNAME and SFU_REGISTRY_PASSWORD must be set together")
+	}
+	if c.ICERelayOnly {
+		if c.TURNServer == "" || c.TURNUsername == "" || c.TURNPassword == "" {
+			return fmt.Errorf("TURN_SERVER, TURN_USERNAME and TURN_PASSWORD are required when ICE_RELAY_ONLY=true")
+		}
+	}
+	return nil
+}
+
+// Render returns an executable cloud-init user-data script for one SFU worker.
+// Values are single-quoted so credentials and URLs cannot alter the shell
+// program. Validate must be called before the renderer is installed.
+func (c WorkerConfig) Render(sfuID, roomID string) string {
+	registry := c.Registry
+	if registry == "" {
+		registry = defaultRegistry
+	}
+	port := c.SFUPort
+	if port == "" {
+		port = "8090"
+	}
+
+	values := []struct {
+		name  string
+		value string
+	}{
+		{"SFU_ID", sfuID},
+		{"ROOM_ID", roomID},
+		{"SFU_IMAGE_TAG", c.ImageTag},
+		{"SFU_REGISTRY", registry},
+		{"SFU_REGISTRY_USERNAME", c.RegistryUser},
+		{"SFU_REGISTRY_PASSWORD", c.RegistryPass},
+		{"SFU_PORT", port},
+		{"CONTROL_PLANE_URL", c.ControlPlaneURL},
+		{"ICE_RELAY_ONLY", fmt.Sprintf("%t", c.ICERelayOnly)},
+		{"ENABLE_ICE_TCP", fmt.Sprintf("%t", c.EnableICETCP)},
+		{"STUN_SERVERS", c.STUNServers},
+		{"TURN_SERVER", c.TURNServer},
+		{"TURN_USERNAME", c.TURNUsername},
+		{"TURN_PASSWORD", c.TURNPassword},
+	}
+
+	var rendered strings.Builder
+	rendered.WriteString("#!/usr/bin/env bash\nset -euo pipefail\n")
+	for _, item := range values {
+		fmt.Fprintf(&rendered, "export %s=%s\n", item.name, shellQuote(item.value))
+	}
+	rendered.WriteString("\n")
+	// The embedded script has its own shebang; omit it when composing the final
+	// user-data so the result remains one valid shell program.
+	script := strings.TrimPrefix(workerBootstrapScript, "#!/usr/bin/env bash\n")
+	rendered.WriteString(script)
+	return rendered.String()
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/sfuServer/deploy/bootstrap_test.go
+++ b/sfuServer/deploy/bootstrap_test.go
@@ -1,0 +1,73 @@
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWorkerConfigValidate(t *testing.T) {
+	valid := WorkerConfig{
+		ImageTag:        "sha-abc123",
+		ControlPlaneURL: "https://sfu.example.com",
+		ICERelayOnly:    true,
+		TURNServer:      "turn:turn.example.com:3478",
+		TURNUsername:    "user",
+		TURNPassword:    "secret",
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*WorkerConfig)
+	}{
+		{"missing image tag", func(c *WorkerConfig) { c.ImageTag = "" }},
+		{"mutable image tag", func(c *WorkerConfig) { c.ImageTag = "latest" }},
+		{"missing control-plane URL", func(c *WorkerConfig) { c.ControlPlaneURL = "" }},
+		{"partial registry credentials", func(c *WorkerConfig) { c.RegistryUser = "user" }},
+		{"missing TURN password", func(c *WorkerConfig) { c.TURNPassword = "" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := valid
+			tt.mutate(&cfg)
+			if err := cfg.Validate(); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestWorkerConfigRender(t *testing.T) {
+	cfg := WorkerConfig{
+		ImageTag:        "sha-abc123",
+		ControlPlaneURL: "https://sfu.example.com",
+		RegistryUser:    "registry-user",
+		RegistryPass:    "pa'ss; echo unsafe",
+		ICERelayOnly:    true,
+		STUNServers:     "stun:stun.example.com:3478",
+		TURNServer:      "turn:turn.example.com:3478",
+		TURNUsername:    "turn-user",
+		TURNPassword:    "turn-secret",
+	}
+
+	rendered := cfg.Render("sfu-123", "room-456")
+	wants := []string{
+		"export SFU_ID='sfu-123'",
+		"export ROOM_ID='room-456'",
+		"export SFU_IMAGE_TAG='sha-abc123'",
+		"export CONTROL_PLANE_URL='https://sfu.example.com'",
+		"export SFU_REGISTRY_PASSWORD='pa'\"'\"'ss; echo unsafe'",
+		"docker run",
+		"-e TURN_PASSWORD=\"${TURN_PASSWORD:-}\"",
+	}
+	for _, want := range wants {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered user-data missing %q", want)
+		}
+	}
+	if strings.Count(rendered, "#!/usr/bin/env bash") != 1 {
+		t.Fatalf("rendered user-data must contain exactly one shebang")
+	}
+}


### PR DESCRIPTION
## Summary

- embed and render the SFU worker bootstrap script as Scaleway cloud-init user-data
- inject immutable image, control-plane, registry and TURN/ICE runtime values
- fail closed before provisioning when bootstrap configuration is incomplete
- shell-quote generated values and add renderer validation tests

## Validation

- `go test ./...`
- `go vet ./...`
- control-plane Docker image build
- bootstrap script `bash -n`

## OpenSpec

Completes the runtime wiring required by task 2.3 of `add-on-demand-sfu-autoscaling`. It does not mark validation tasks 8.1-8.6 complete.