### PR TITLE
feat(sfu): attach security group to ephemeral workers

### DIFF
--- a/sfuServer/.env.example
+++ b/sfuServer/.env.example
@@ -88,6 +88,9 @@ CASCADE_AUTH_KEY=your-secure-cascade-key-here
 # Example: 203.0.113.42 (your public IP)
 # PUBLIC_IP=
 
+# Terraform-managed security group attached to every ephemeral SFU worker.
+# SFU_WORKER_SECURITY_GROUP_ID=00000000-0000-0000-0000-000000000000
+
 # Enable ICE-TCP (for environments without UDP support)
 # Set to "true" to enable TCP-based ICE candidates
 # Useful for restrictive networks that block UDP

--- a/sfuServer/cmd/controlplane/main.go
+++ b/sfuServer/cmd/controlplane/main.go
@@ -106,12 +106,13 @@ func wireAutoscaler(cp *controlplane.ControlPlane) error {
 	}
 
 	adapter, err := scaleway.New(scaleway.Config{
-		AccessKey:      os.Getenv("SCW_ACCESS_KEY"),
-		SecretKey:      os.Getenv("SCW_SECRET_KEY"),
-		ProjectID:      os.Getenv("SCW_DEFAULT_PROJECT_ID"),
-		Zone:           getEnv("SCW_DEFAULT_ZONE", "fr-par-1"),
-		CommercialType: getEnv("SFU_WORKER_TYPE", "DEV1-S"),
-		ImageID:        os.Getenv("SFU_WORKER_IMAGE_ID"),
+		AccessKey:       os.Getenv("SCW_ACCESS_KEY"),
+		SecretKey:       os.Getenv("SCW_SECRET_KEY"),
+		ProjectID:       os.Getenv("SCW_DEFAULT_PROJECT_ID"),
+		Zone:            getEnv("SCW_DEFAULT_ZONE", "fr-par-1"),
+		CommercialType:  getEnv("SFU_WORKER_TYPE", "DEV1-S"),
+		ImageID:         os.Getenv("SFU_WORKER_IMAGE_ID"),
+		SecurityGroupID: os.Getenv("SFU_WORKER_SECURITY_GROUP_ID"),
 	})
 	if err != nil {
 		return err

--- a/sfuServer/internal/provider/scaleway/scaleway.go
+++ b/sfuServer/internal/provider/scaleway/scaleway.go
@@ -17,21 +17,23 @@ import (
 // Config carries the static Scaleway settings promoted via GitOps (task 7.3)
 // plus the credential injected from a Kubernetes Secret at runtime (task 7.4).
 type Config struct {
-	AccessKey      string // SCW_ACCESS_KEY
-	SecretKey      string // SCW_SECRET_KEY
-	ProjectID      string // SCW_DEFAULT_PROJECT_ID
-	Zone           string // e.g. "fr-par-1"
-	CommercialType string // worker Instance type, defaults to DEV1-S
-	ImageID        string // Docker-capable base image id or label
+	AccessKey       string // SCW_ACCESS_KEY
+	SecretKey       string // SCW_SECRET_KEY
+	ProjectID       string // SCW_DEFAULT_PROJECT_ID
+	Zone            string // e.g. "fr-par-1"
+	CommercialType  string // worker Instance type, defaults to DEV1-S
+	ImageID         string // Docker-capable base image id or label
+	SecurityGroupID string // Terraform-managed SFU worker security group
 }
 
 // Adapter is the Scaleway implementation of provider.Provider.
 type Adapter struct {
-	api            *instance.API
-	zone           scw.Zone
-	projectID      string
-	commercialType string
-	imageID        string
+	api             *instance.API
+	zone            scw.Zone
+	projectID       string
+	commercialType  string
+	imageID         string
+	securityGroupID string
 }
 
 var _ provider.Provider = (*Adapter)(nil)
@@ -44,6 +46,9 @@ func New(cfg Config) (*Adapter, error) {
 	}
 	if cfg.ImageID == "" {
 		return nil, fmt.Errorf("scaleway: image id is required")
+	}
+	if cfg.SecurityGroupID == "" {
+		return nil, fmt.Errorf("scaleway: security group id is required")
 	}
 	zone, err := scw.ParseZone(cfg.Zone)
 	if err != nil {
@@ -62,11 +67,12 @@ func New(cfg Config) (*Adapter, error) {
 		ct = "DEV1-S"
 	}
 	return &Adapter{
-		api:            instance.NewAPI(client),
-		zone:           zone,
-		projectID:      cfg.ProjectID,
-		commercialType: ct,
-		imageID:        cfg.ImageID,
+		api:             instance.NewAPI(client),
+		zone:            zone,
+		projectID:       cfg.ProjectID,
+		commercialType:  ct,
+		imageID:         cfg.ImageID,
+		securityGroupID: cfg.SecurityGroupID,
 	}, nil
 }
 
@@ -76,15 +82,7 @@ func (a *Adapter) Name() string { return "scaleway" }
 // on. If bootstrap or boot fails the half-created Instance is terminated so it
 // never becomes an orphaned billable resource.
 func (a *Adapter) CreateWorker(ctx context.Context, spec provider.WorkerSpec) (provider.Worker, error) {
-	res, err := a.api.CreateServer(&instance.CreateServerRequest{
-		Zone:              a.zone,
-		Name:              spec.Name,
-		CommercialType:    a.commercialType,
-		Image:             scw.StringPtr(a.imageID),
-		DynamicIPRequired: scw.BoolPtr(true), // dynamic IP is released on terminate
-		Tags:              spec.Tags,
-		Project:           scw.StringPtr(a.projectID),
-	}, scw.WithContext(ctx))
+	res, err := a.api.CreateServer(a.createServerRequest(spec), scw.WithContext(ctx))
 	if err != nil {
 		return provider.Worker{}, fmt.Errorf("scaleway: create server: %w", err)
 	}
@@ -112,6 +110,19 @@ func (a *Adapter) CreateWorker(ctx context.Context, spec provider.WorkerSpec) (p
 	}
 
 	return toWorker(srv), nil
+}
+
+func (a *Adapter) createServerRequest(spec provider.WorkerSpec) *instance.CreateServerRequest {
+	return &instance.CreateServerRequest{
+		Zone:              a.zone,
+		Name:              spec.Name,
+		CommercialType:    a.commercialType,
+		Image:             scw.StringPtr(a.imageID),
+		SecurityGroup:     scw.StringPtr(a.securityGroupID),
+		DynamicIPRequired: scw.BoolPtr(true), // dynamic IP is released on terminate
+		Tags:              spec.Tags,
+		Project:           scw.StringPtr(a.projectID),
+	}
 }
 
 func (a *Adapter) GetWorker(ctx context.Context, id string) (provider.Worker, error) {

--- a/sfuServer/internal/provider/scaleway/scaleway.go
+++ b/sfuServer/internal/provider/scaleway/scaleway.go
@@ -113,6 +113,7 @@ func (a *Adapter) CreateWorker(ctx context.Context, spec provider.WorkerSpec) (p
 }
 
 func (a *Adapter) createServerRequest(spec provider.WorkerSpec) *instance.CreateServerRequest {
+	rootVolumeSize := scw.GB * 10
 	return &instance.CreateServerRequest{
 		Zone:              a.zone,
 		Name:              spec.Name,
@@ -120,8 +121,15 @@ func (a *Adapter) createServerRequest(spec provider.WorkerSpec) *instance.Create
 		Image:             scw.StringPtr(a.imageID),
 		SecurityGroup:     scw.StringPtr(a.securityGroupID),
 		DynamicIPRequired: scw.BoolPtr(true), // dynamic IP is released on terminate
-		Tags:              spec.Tags,
-		Project:           scw.StringPtr(a.projectID),
+		Volumes: map[string]*instance.VolumeServerTemplate{
+			"0": {
+				Boot:       scw.BoolPtr(true),
+				Size:       &rootVolumeSize,
+				VolumeType: instance.VolumeVolumeTypeLSSD,
+			},
+		},
+		Tags:    spec.Tags,
+		Project: scw.StringPtr(a.projectID),
 	}
 }
 

--- a/sfuServer/internal/provider/scaleway/scaleway_test.go
+++ b/sfuServer/internal/provider/scaleway/scaleway_test.go
@@ -1,0 +1,47 @@
+package scaleway
+
+import (
+	"testing"
+
+	"github.com/scaleway/scaleway-sdk-go/scw"
+
+	"whip-server/internal/provider"
+)
+
+func TestCreateServerRequestAttachesConfiguredSecurityGroup(t *testing.T) {
+	adapter := &Adapter{
+		zone:            scw.ZoneFrPar1,
+		projectID:       "project-id",
+		commercialType:  "DEV1-S",
+		imageID:         "image-id",
+		securityGroupID: "security-group-id",
+	}
+
+	req := adapter.createServerRequest(provider.WorkerSpec{
+		Name: "sfu-worker-1",
+		Tags: []string{"sfu-worker", "cleanup-eligible"},
+	})
+
+	if req.SecurityGroup == nil || *req.SecurityGroup != "security-group-id" {
+		t.Fatalf("security group = %v, want security-group-id", req.SecurityGroup)
+	}
+	if req.Image == nil || *req.Image != "image-id" {
+		t.Fatalf("image = %v, want image-id", req.Image)
+	}
+	if req.DynamicIPRequired == nil || !*req.DynamicIPRequired {
+		t.Fatal("dynamic IP must be requested")
+	}
+}
+
+func TestNewRequiresSecurityGroup(t *testing.T) {
+	_, err := New(Config{
+		AccessKey: "access",
+		SecretKey: "secret",
+		ProjectID: "project",
+		Zone:      "fr-par-1",
+		ImageID:   "image",
+	})
+	if err == nil {
+		t.Fatal("expected missing security group error")
+	}
+}

--- a/sfuServer/internal/provider/scaleway/scaleway_test.go
+++ b/sfuServer/internal/provider/scaleway/scaleway_test.go
@@ -31,6 +31,19 @@ func TestCreateServerRequestAttachesConfiguredSecurityGroup(t *testing.T) {
 	if req.DynamicIPRequired == nil || !*req.DynamicIPRequired {
 		t.Fatal("dynamic IP must be requested")
 	}
+	root := req.Volumes["0"]
+	if root == nil {
+		t.Fatal("root volume must be configured")
+	}
+	if root.Size == nil || *root.Size != scw.GB*10 {
+		t.Fatalf("root volume size = %v, want 10 GB", root.Size)
+	}
+	if root.VolumeType != "l_ssd" {
+		t.Fatalf("root volume type = %q, want l_ssd", root.VolumeType)
+	}
+	if root.Boot == nil || !*root.Boot {
+		t.Fatal("root volume must be bootable")
+	}
 }
 
 func TestNewRequiresSecurityGroup(t *testing.T) {


### PR DESCRIPTION
## Summary

- require the Terraform-managed SFU worker security group in Scaleway adapter configuration
- attach it to every `CreateServer` request
- fail closed before provisioning when the security group ID is missing
- keep security-group configuration isolated in the Scaleway adapter
- add request-construction tests

## Validation

- `go test ./...`
- `git diff --check`

## Runtime configuration

Requires `SFU_WORKER_SECURITY_GROUP_ID`, sourced from the `terraform/sfu-support` output.