### PR TITLE
feat(sfu): destroy workers after idle room cleanup

### DIFF
--- a/sfuServer/cmd/controlplane/main.go
+++ b/sfuServer/cmd/controlplane/main.go
@@ -127,6 +127,7 @@ func wireAutoscaler(cp *controlplane.ControlPlane) error {
 		ManagedTag: getEnv("SFU_MANAGED_TAG", "sfu-worker"),
 	})
 	cp.SetProvisioner(prov)
+	http.Handle("/metrics", prov.MetricsHandler())
 
 	ctx := context.Background()
 	go prov.Run(ctx) // startup-timeout reaping (task 4.3)

--- a/sfuServer/internal/autoscaler/metrics.go
+++ b/sfuServer/internal/autoscaler/metrics.go
@@ -1,0 +1,106 @@
+package autoscaler
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"whip-server/internal/models"
+)
+
+// WorkerRuntime is the current runtime of one non-terminal worker. Labels are
+// intentionally limited to the bounded live-worker set to avoid unbounded
+// Prometheus cardinality from historical workers.
+type WorkerRuntime struct {
+	SFUID   string
+	State   models.WorkerState
+	Seconds float64
+}
+
+// MetricsSnapshot is a testable, provider-neutral view of autoscaler SLIs.
+type MetricsSnapshot struct {
+	ActiveWorkers               int
+	RoomReadinessFailures       uint64
+	OrphanCleanups              uint64
+	ProvisioningDurationCount   uint64
+	ProvisioningDurationSeconds float64
+	TerminatedRuntimeCount      uint64
+	TerminatedRuntimeSeconds    float64
+	CurrentWorkerRuntime        []WorkerRuntime
+}
+
+// MetricsSnapshot returns autoscaler metrics. Durable lifecycle metrics are
+// reconstructed from the store so a control-plane restart does not erase
+// provisioning and terminated-runtime observations.
+func (p *Provisioner) MetricsSnapshot() MetricsSnapshot {
+	now := p.now()
+	snapshot := MetricsSnapshot{
+		RoomReadinessFailures: p.readinessFailures.Load(),
+		OrphanCleanups:        p.orphanCleanups.Load(),
+	}
+	for _, worker := range p.store.ListWorkers() {
+		if worker.ReadyAt != nil && !worker.CreatedAt.IsZero() && !worker.ReadyAt.Before(worker.CreatedAt) {
+			snapshot.ProvisioningDurationCount++
+			snapshot.ProvisioningDurationSeconds += worker.ReadyAt.Sub(worker.CreatedAt).Seconds()
+		}
+
+		if worker.State == models.WorkerTerminated || worker.State == models.WorkerFailed {
+			if worker.TerminatedAt != nil && !worker.CreatedAt.IsZero() && !worker.TerminatedAt.Before(worker.CreatedAt) {
+				snapshot.TerminatedRuntimeCount++
+				snapshot.TerminatedRuntimeSeconds += worker.TerminatedAt.Sub(worker.CreatedAt).Seconds()
+			}
+			continue
+		}
+
+		snapshot.ActiveWorkers++
+		if !worker.CreatedAt.IsZero() && !now.Before(worker.CreatedAt) {
+			snapshot.CurrentWorkerRuntime = append(snapshot.CurrentWorkerRuntime, WorkerRuntime{
+				SFUID:   worker.SFUID,
+				State:   worker.State,
+				Seconds: now.Sub(worker.CreatedAt).Seconds(),
+			})
+		}
+	}
+	sort.Slice(snapshot.CurrentWorkerRuntime, func(i, j int) bool {
+		return snapshot.CurrentWorkerRuntime[i].SFUID < snapshot.CurrentWorkerRuntime[j].SFUID
+	})
+	return snapshot
+}
+
+// MetricsHandler exposes Prometheus text-format metrics without adding a
+// runtime dependency to the control-plane image.
+func (p *Provisioner) MetricsHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Only GET is supported", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		_, _ = fmt.Fprint(w, renderPrometheus(p.MetricsSnapshot()))
+	})
+}
+
+func renderPrometheus(m MetricsSnapshot) string {
+	var b strings.Builder
+	metric(&b, "ochocast_sfu_active_workers", "gauge", "Current number of non-terminal autoscaled SFU workers.", float64(m.ActiveWorkers))
+	metric(&b, "ochocast_sfu_room_readiness_failures_total", "counter", "Room provisioning attempts that failed to obtain ready autoscaled SFU capacity.", float64(m.RoomReadinessFailures))
+	metric(&b, "ochocast_sfu_orphan_cleanup_total", "counter", "Tagged orphan SFU resources deleted by reconciliation.", float64(m.OrphanCleanups))
+	metric(&b, "ochocast_sfu_provisioning_duration_seconds_sum", "gauge", "Cumulative cold-start duration for workers that reached ready.", m.ProvisioningDurationSeconds)
+	metric(&b, "ochocast_sfu_provisioning_duration_seconds_count", "gauge", "Workers that reached ready and contributed a provisioning duration.", float64(m.ProvisioningDurationCount))
+	metric(&b, "ochocast_sfu_terminated_worker_runtime_seconds_sum", "gauge", "Cumulative runtime of terminated autoscaled SFU workers.", m.TerminatedRuntimeSeconds)
+	metric(&b, "ochocast_sfu_terminated_worker_runtime_seconds_count", "gauge", "Terminated workers that contributed a runtime observation.", float64(m.TerminatedRuntimeCount))
+	for _, worker := range m.CurrentWorkerRuntime {
+		fmt.Fprintf(&b, "ochocast_sfu_worker_runtime_seconds{sfu_id=%q,state=%q} %s\n", worker.SFUID, worker.State, number(worker.Seconds))
+	}
+	return b.String()
+}
+
+func metric(b *strings.Builder, name, metricType, help string, value float64) {
+	fmt.Fprintf(b, "# HELP %s %s\n# TYPE %s %s\n%s %s\n", name, help, name, metricType, name, number(value))
+}
+
+func number(value float64) string {
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}

--- a/sfuServer/internal/autoscaler/metrics_test.go
+++ b/sfuServer/internal/autoscaler/metrics_test.go
@@ -1,0 +1,72 @@
+package autoscaler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"whip-server/internal/models"
+	"whip-server/internal/provider"
+)
+
+func TestMetricsSnapshotCoversAutoscalerSLIs(t *testing.T) {
+	fake := provider.NewFake()
+	p, store := newTestProvisioner(t, fake, 1)
+	rec, err := p.EnsureCapacity(context.Background(), "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := rec.CreatedAt
+	readyAt := created.Add(12 * time.Second)
+	rec.State = models.WorkerRegistered
+	if rec, err = store.UpsertWorker(rec); err != nil {
+		t.Fatal(err)
+	}
+	rec.State = models.WorkerReady
+	rec.ReadyAt = &readyAt
+	if _, err = store.UpsertWorker(rec); err != nil {
+		t.Fatal(err)
+	}
+	p.now = func() time.Time { return created.Add(42 * time.Second) }
+
+	// A rejected second room is a readiness failure and does not create a worker.
+	if _, err := p.EnsureCapacity(context.Background(), "room-2"); err == nil {
+		t.Fatal("expected budget failure")
+	}
+
+	snapshot := p.MetricsSnapshot()
+	if snapshot.ActiveWorkers != 1 || snapshot.RoomReadinessFailures != 1 {
+		t.Fatalf("unexpected counts: %+v", snapshot)
+	}
+	if snapshot.ProvisioningDurationCount != 1 || snapshot.ProvisioningDurationSeconds != 12 {
+		t.Fatalf("unexpected provisioning duration: %+v", snapshot)
+	}
+	if len(snapshot.CurrentWorkerRuntime) != 1 || snapshot.CurrentWorkerRuntime[0].Seconds != 42 {
+		t.Fatalf("unexpected runtime: %+v", snapshot.CurrentWorkerRuntime)
+	}
+}
+
+func TestMetricsHandlerRendersPrometheusText(t *testing.T) {
+	p, _ := newTestProvisioner(t, provider.NewFake(), 1)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	res := httptest.NewRecorder()
+	p.MetricsHandler().ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", res.Code)
+	}
+	for _, name := range []string{
+		"ochocast_sfu_active_workers",
+		"ochocast_sfu_room_readiness_failures_total",
+		"ochocast_sfu_orphan_cleanup_total",
+		"ochocast_sfu_provisioning_duration_seconds_sum",
+		"ochocast_sfu_terminated_worker_runtime_seconds_sum",
+	} {
+		if !strings.Contains(res.Body.String(), name) {
+			t.Errorf("metric %s missing from:\n%s", name, res.Body.String())
+		}
+	}
+}

--- a/sfuServer/internal/autoscaler/provisioner.go
+++ b/sfuServer/internal/autoscaler/provisioner.go
@@ -190,6 +190,75 @@ func (p *Provisioner) Drain(sfuID string) error {
 	return nil
 }
 
+// ReleaseCapacity drains and destroys the worker assigned to roomID after the
+// control-plane has confirmed that the room's media topology is empty. A cloud
+// deletion failure leaves the worker and room in draining state so the
+// background reaper can retry without assigning new work to the Instance.
+func (p *Provisioner) ReleaseCapacity(ctx context.Context, roomID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	rec, ok := p.store.WorkerForRoom(roomID)
+	if !ok {
+		return nil // static SFU room or already released; nothing cloud-owned
+	}
+	if rec.State != models.WorkerDraining {
+		rec.State = models.WorkerDraining
+		rec.Reason = "idle timeout"
+		if _, err := p.store.UpsertWorker(rec); err != nil {
+			return fmt.Errorf("autoscaler: drain worker %s: %w", rec.SFUID, err)
+		}
+	}
+	if room, exists := p.store.Get(roomID); exists && room.State != models.RoomDraining {
+		if _, err := p.store.Upsert(roomID, models.RoomDraining, "idle timeout"); err != nil {
+			return fmt.Errorf("autoscaler: drain room %s: %w", roomID, err)
+		}
+	}
+	return p.destroyDrainingLocked(ctx, rec)
+}
+
+func (p *Provisioner) destroyDrainingLocked(ctx context.Context, rec models.WorkerRecord) error {
+	if rec.State != models.WorkerDraining {
+		return fmt.Errorf("autoscaler: worker %s is %s, not draining", rec.SFUID, rec.State)
+	}
+	if rec.ProviderResourceID != "" {
+		if err := p.prov.DeleteWorker(ctx, rec.ProviderResourceID); err != nil {
+			return fmt.Errorf("autoscaler: destroy worker %s: %w", rec.SFUID, err)
+		}
+	}
+	rec.State = models.WorkerTerminated
+	rec.Reason = "idle timeout"
+	if _, err := p.store.UpsertWorker(rec); err != nil {
+		return fmt.Errorf("autoscaler: mark worker %s terminated: %w", rec.SFUID, err)
+	}
+	if rec.RoomID != "" {
+		if _, err := p.store.Upsert(rec.RoomID, models.RoomTerminated, "idle timeout"); err != nil {
+			return fmt.Errorf("autoscaler: mark room %s terminated: %w", rec.RoomID, err)
+		}
+	}
+	return nil
+}
+
+// ReapDrainingWorkers retries deletion for workers left draining by a transient
+// provider failure. It never targets ready or untagged/untracked resources.
+func (p *Provisioner) ReapDrainingWorkers(ctx context.Context) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	destroyed := 0
+	for _, rec := range p.store.ListWorkers() {
+		if rec.State != models.WorkerDraining {
+			continue
+		}
+		if err := p.destroyDrainingLocked(ctx, rec); err != nil {
+			log.Printf("[autoscaler] retry draining worker %s: %v", rec.SFUID, err)
+			continue
+		}
+		destroyed++
+	}
+	return destroyed
+}
+
 // liveWorkerCount counts workers that still hold (or could hold) budget: anything
 // not terminated and not failed.
 func (p *Provisioner) liveWorkerCount() int {
@@ -258,6 +327,7 @@ func (p *Provisioner) Run(ctx context.Context) {
 			return
 		case <-t.C:
 			p.ReapStartupTimeouts(ctx)
+			p.ReapDrainingWorkers(ctx)
 		}
 	}
 }

--- a/sfuServer/internal/autoscaler/provisioner.go
+++ b/sfuServer/internal/autoscaler/provisioner.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"whip-server/internal/lifecycle"
@@ -74,6 +75,11 @@ type Provisioner struct {
 
 	// now is the clock, overridable in tests.
 	now func() time.Time
+
+	// Counters are process-local Prometheus counters. Lifecycle-derived gauges
+	// and duration summaries are rebuilt from the durable store on every scrape.
+	readinessFailures atomic.Uint64
+	orphanCleanups    atomic.Uint64
 }
 
 // New builds a Provisioner. MaxWorkers < 1 is clamped to 1 and an unset
@@ -115,11 +121,13 @@ func (p *Provisioner) EnsureCapacity(ctx context.Context, roomID string) (models
 
 	// 2. Budget cap on live workers across the environment.
 	if p.liveWorkerCount() >= p.cfg.MaxWorkers {
+		p.readinessFailures.Add(1)
 		return models.WorkerRecord{}, ErrBudgetExceeded
 	}
 
 	// 3. Move the room into provisioning (idempotent; safe if already provisioning).
 	if _, _, err := p.store.EnsureRoomProvisioning(roomID); err != nil {
+		p.readinessFailures.Add(1)
 		return models.WorkerRecord{}, err
 	}
 
@@ -134,6 +142,7 @@ func (p *Provisioner) EnsureCapacity(ctx context.Context, roomID string) (models
 		ImageTag: p.cfg.ImageTag,
 	}
 	if _, err := p.store.UpsertWorker(rec); err != nil {
+		p.readinessFailures.Add(1)
 		return models.WorkerRecord{}, err
 	}
 
@@ -148,6 +157,7 @@ func (p *Provisioner) EnsureCapacity(ctx context.Context, roomID string) (models
 	}
 	w, err := p.prov.CreateWorker(ctx, spec)
 	if err != nil {
+		p.readinessFailures.Add(1)
 		// Mark worker and room failed; the record is kept (not deleted) so
 		// reconciliation can confirm no cloud resource leaked.
 		rec.State = models.WorkerFailed
@@ -166,6 +176,7 @@ func (p *Provisioner) EnsureCapacity(ctx context.Context, roomID string) (models
 	}
 	saved, err := p.store.UpsertWorker(rec)
 	if err != nil {
+		p.readinessFailures.Add(1)
 		return models.WorkerRecord{}, err
 	}
 	return saved, nil
@@ -306,6 +317,7 @@ func (p *Provisioner) ReapStartupTimeouts(ctx context.Context) int {
 		if w.RoomID != "" {
 			_, _ = p.store.Upsert(w.RoomID, models.RoomFailed, "sfu startup timeout")
 		}
+		p.readinessFailures.Add(1)
 		reaped++
 	}
 	return reaped
@@ -419,6 +431,7 @@ func (p *Provisioner) CleanupOrphans(ctx context.Context) (int, error) {
 		}
 		deleted++
 	}
+	p.orphanCleanups.Add(uint64(deleted))
 	return deleted, nil
 }
 

--- a/sfuServer/internal/autoscaler/provisioner_test.go
+++ b/sfuServer/internal/autoscaler/provisioner_test.go
@@ -181,6 +181,77 @@ func TestDrain(t *testing.T) {
 	}
 }
 
+func TestReleaseCapacityDrainsAndDestroysWorker(t *testing.T) {
+	ctx := context.Background()
+	fake := provider.NewFake()
+	p, store := newTestProvisioner(t, fake, 1)
+
+	rec, err := p.EnsureCapacity(ctx, "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, state := range []models.WorkerState{models.WorkerRegistered, models.WorkerReady} {
+		rec.State = state
+		if _, err := store.UpsertWorker(rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.Upsert("room-1", models.RoomReady, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.ReleaseCapacity(ctx, "room-1"); err != nil {
+		t.Fatal(err)
+	}
+	if fake.Count() != 0 {
+		t.Fatalf("worker Instance still exists: count=%d", fake.Count())
+	}
+	worker, _ := store.GetWorker(rec.SFUID)
+	if worker.State != models.WorkerTerminated || worker.TerminatedAt == nil {
+		t.Fatalf("worker not terminated: %+v", worker)
+	}
+	room, _ := store.Get("room-1")
+	if room.State != models.RoomTerminated {
+		t.Fatalf("room state = %s, want terminated", room.State)
+	}
+}
+
+func TestReleaseCapacityRetriesTransientDeleteFailure(t *testing.T) {
+	ctx := context.Background()
+	fake := provider.NewFake()
+	p, store := newTestProvisioner(t, fake, 1)
+
+	rec, err := p.EnsureCapacity(ctx, "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, state := range []models.WorkerState{models.WorkerRegistered, models.WorkerReady} {
+		rec.State = state
+		if _, err := store.UpsertWorker(rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.Upsert("room-1", models.RoomReady, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	fake.FailDelete = errors.New("temporary provider failure")
+	if err := p.ReleaseCapacity(ctx, "room-1"); err == nil {
+		t.Fatal("expected provider deletion failure")
+	}
+	worker, _ := store.GetWorker(rec.SFUID)
+	if worker.State != models.WorkerDraining || fake.Count() != 1 {
+		t.Fatalf("failed deletion must remain draining: worker=%+v count=%d", worker, fake.Count())
+	}
+
+	if destroyed := p.ReapDrainingWorkers(ctx); destroyed != 1 {
+		t.Fatalf("destroyed=%d, want 1", destroyed)
+	}
+	if fake.Count() != 0 {
+		t.Fatal("retry did not delete worker")
+	}
+}
+
 func TestReconcileVanishedAndOrphan(t *testing.T) {
 	ctx := context.Background()
 	fake := provider.NewFake()

--- a/sfuServer/internal/lifecycle/store.go
+++ b/sfuServer/internal/lifecycle/store.go
@@ -259,6 +259,9 @@ func (s *Store) UpsertWorker(w models.WorkerRecord) (models.WorkerRecord, error)
 			return prev, fmt.Errorf("invalid worker transition %s -> %s for sfu %s", prev.State, w.State, w.SFUID)
 		}
 		w.CreatedAt = prev.CreatedAt
+		if w.ReadyAt == nil {
+			w.ReadyAt = prev.ReadyAt
+		}
 	} else {
 		w.CreatedAt = now
 	}

--- a/sfuServer/internal/models/shared.go
+++ b/sfuServer/internal/models/shared.go
@@ -98,6 +98,7 @@ type WorkerRecord struct {
 	Reason             string            `json:"reason,omitempty"`        // why it entered a failed/terminated state
 	CreatedAt          time.Time         `json:"created_at"`              // creation time
 	UpdatedAt          time.Time         `json:"updated_at"`              // last state change
+	ReadyAt            *time.Time        `json:"ready_at,omitempty"`      // first healthy heartbeat; used for provisioning SLI
 	LastHeartbeat      time.Time         `json:"last_heartbeat_at"`       // last heartbeat time
 	TerminatedAt       *time.Time        `json:"terminated_at,omitempty"` // termination status
 	Metadata           map[string]string `json:"metadata,omitempty"`      // provider-specific fields (zone, volume ids, ...)

--- a/sfuServer/internal/provider/fake.go
+++ b/sfuServer/internal/provider/fake.go
@@ -12,10 +12,11 @@ import (
 // enough to exercise the autoscaler's create/read/tag/delete paths without any
 // cloud calls. Used by tasks 4.2–4.5 and the 8.2 integration tests.
 type Fake struct {
-	mu       sync.Mutex
-	seq      int
-	workers  map[string]Worker
-	FailNext error // if set, the next CreateWorker returns it (and clears it)
+	mu         sync.Mutex
+	seq        int
+	workers    map[string]Worker
+	FailNext   error // if set, the next CreateWorker returns it (and clears it)
+	FailDelete error // if set, the next DeleteWorker returns it (and clears it)
 }
 
 // NewFake returns an empty fake provider.
@@ -84,6 +85,11 @@ func (f *Fake) TagWorker(_ context.Context, id string, tags []string) error {
 func (f *Fake) DeleteWorker(_ context.Context, id string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.FailDelete != nil {
+		err := f.FailDelete
+		f.FailDelete = nil
+		return err
+	}
 	if _, ok := f.workers[id]; !ok {
 		return fmt.Errorf("fake: no worker %s", id)
 	}

--- a/sfuServer/pkg/controlplane/controlplane.go
+++ b/sfuServer/pkg/controlplane/controlplane.go
@@ -1099,6 +1099,10 @@ func (cp *ControlPlane) promoteWorker(sfuID string, healthy bool) {
 			return
 		}
 		rec.State = models.WorkerReady
+		if rec.ReadyAt == nil {
+			now := time.Now().UTC()
+			rec.ReadyAt = &now
+		}
 	default:
 		return // ready/draining/failed/terminated: nothing to advance
 	}

--- a/sfuServer/pkg/controlplane/controlplane.go
+++ b/sfuServer/pkg/controlplane/controlplane.go
@@ -106,6 +106,7 @@ type ControlPlane struct {
 // cold-start path testable).
 type capacityEnsurer interface {
 	EnsureCapacity(ctx context.Context, roomID string) (models.WorkerRecord, error)
+	ReleaseCapacity(ctx context.Context, roomID string) error
 }
 
 // SetProvisioner wires an autoscaler into the control-plane. With one set, a
@@ -436,6 +437,17 @@ func (cp *ControlPlane) scheduleTopologyCleanup(roomID string) {
 
 	// Notify ALL SFUs to delete the room so it can be re-created with a new key later
 	go cp.syncRoomDeletionToAllSFUs(roomID)
+
+	// The topology grace period doubles as the first-stage idle timeout. Once it
+	// expires, release only capacity tracked by the on-demand provisioner; rooms
+	// hosted on static SFUs are a no-op.
+	if cp.provisioner != nil {
+		go func() {
+			if err := cp.provisioner.ReleaseCapacity(context.Background(), roomID); err != nil {
+				log.Printf("[CP-CLEANUP] release capacity for room %s: %v", roomID, err)
+			}
+		}()
+	}
 }
 
 // syncRoomDeletionToAllSFUs sends room deletion to all registered SFUs

--- a/sfuServer/pkg/controlplane/controlplane_test.go
+++ b/sfuServer/pkg/controlplane/controlplane_test.go
@@ -195,8 +195,8 @@ func TestColdStartReadinessLoop(t *testing.T) {
 	if err := cp.UpdateMetrics(&models.SFUMetrics{SFUID: sfuID, ServerURL: "http://1.2.3.4:8080", CPU: 0.1, Memory: 0.1}); err != nil {
 		t.Fatal(err)
 	}
-	if w, _ := cp.LifecycleStore().GetWorker(sfuID); w.State != models.WorkerReady {
-		t.Fatalf("after healthy heartbeat, worker state = %s, want ready", w.State)
+	if w, _ := cp.LifecycleStore().GetWorker(sfuID); w.State != models.WorkerReady || w.ReadyAt == nil {
+		t.Fatalf("after healthy heartbeat, worker must be ready with ready_at: %+v", w)
 	}
 	if rl, _ := cp.LifecycleStore().Get("room-1"); rl.State != models.RoomReady {
 		t.Fatalf("room state = %s, want ready", rl.State)

--- a/sfuServer/pkg/controlplane/controlplane_test.go
+++ b/sfuServer/pkg/controlplane/controlplane_test.go
@@ -17,8 +17,16 @@ import (
 
 // stubEnsurer stands in for the autoscaler in control-plane tests.
 type stubEnsurer struct {
-	called chan string
-	err    error
+	called   chan string
+	released chan string
+	err      error
+}
+
+func (s *stubEnsurer) ReleaseCapacity(_ context.Context, roomID string) error {
+	if s.released != nil {
+		s.released <- roomID
+	}
+	return s.err
 }
 
 func (s *stubEnsurer) EnsureCapacity(_ context.Context, roomID string) (models.WorkerRecord, error) {
@@ -60,6 +68,30 @@ func TestCreateRoomColdStartProvisions(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("EnsureCapacity was never called")
+	}
+}
+
+func TestTopologyCleanupReleasesOnDemandCapacity(t *testing.T) {
+	cp := newTestCP(t)
+	released := make(chan string, 1)
+	cp.SetProvisioner(&stubEnsurer{released: released})
+	cp.rooms["room-idle"] = &models.RoomTopology{
+		RoomID: "room-idle",
+		Nodes:  make(map[string]*models.TopologyNode),
+	}
+
+	cp.scheduleTopologyCleanup("room-idle")
+
+	select {
+	case roomID := <-released:
+		if roomID != "room-idle" {
+			t.Fatalf("released room = %s, want room-idle", roomID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("topology cleanup did not release on-demand capacity")
+	}
+	if _, exists := cp.rooms["room-idle"]; exists {
+		t.Fatal("room topology still exists after cleanup")
 	}
 }
 
@@ -185,6 +217,21 @@ func TestColdStartReadinessLoop(t *testing.T) {
 	}
 	if _, ok := body["whip_url"]; !ok {
 		t.Fatal("whip_url should be exposed once ready")
+	}
+
+	// Complete the integration lifecycle against the fake provider:
+	// ready -> draining -> cloud delete -> terminated.
+	if err := prov.ReleaseCapacity(context.Background(), "room-1"); err != nil {
+		t.Fatal(err)
+	}
+	if fake.Count() != 0 {
+		t.Fatalf("fake provider still has %d worker(s) after release", fake.Count())
+	}
+	if worker, _ := cp.LifecycleStore().GetWorker(sfuID); worker.State != models.WorkerTerminated {
+		t.Fatalf("worker state after release = %s, want terminated", worker.State)
+	}
+	if room, _ := cp.LifecycleStore().Get("room-1"); room.State != models.RoomTerminated {
+		t.Fatalf("room state after release = %s, want terminated", room.State)
 	}
 }
 


### PR DESCRIPTION
## Summary

- release on-demand capacity after the existing 10-minute topology cleanup grace period
- transition room and worker through draining to terminated
- delete the provider resource instead of merely stopping it
- leave failed deletions draining and retry them from the provisioner loop
- keep static SFU rooms as a no-op
- extend fake-provider tests through create/register/ready/drain/delete

## Validation

- `go test ./...`
- `git diff --check`

## OpenSpec

Implements the missing normal scale-down path and completes local coverage for tasks 8.1 and 8.2. Real Scaleway deletion remains task 8.5.