### PR TITLE
feat(sfu): cap worker root volume at 10 GB

### DIFF
--- a/sfuServer/internal/provider/scaleway/scaleway.go
+++ b/sfuServer/internal/provider/scaleway/scaleway.go
@@ -113,6 +113,7 @@ func (a *Adapter) CreateWorker(ctx context.Context, spec provider.WorkerSpec) (p
 }
 
 func (a *Adapter) createServerRequest(spec provider.WorkerSpec) *instance.CreateServerRequest {
+	rootVolumeSize := scw.GB * 10
 	return &instance.CreateServerRequest{
 		Zone:              a.zone,
 		Name:              spec.Name,
@@ -120,8 +121,15 @@ func (a *Adapter) createServerRequest(spec provider.WorkerSpec) *instance.Create
 		Image:             scw.StringPtr(a.imageID),
 		SecurityGroup:     scw.StringPtr(a.securityGroupID),
 		DynamicIPRequired: scw.BoolPtr(true), // dynamic IP is released on terminate
-		Tags:              spec.Tags,
-		Project:           scw.StringPtr(a.projectID),
+		Volumes: map[string]*instance.VolumeServerTemplate{
+			"0": {
+				Boot:       scw.BoolPtr(true),
+				Size:       &rootVolumeSize,
+				VolumeType: instance.VolumeVolumeTypeLSSD,
+			},
+		},
+		Tags:    spec.Tags,
+		Project: scw.StringPtr(a.projectID),
 	}
 }
 

--- a/sfuServer/internal/provider/scaleway/scaleway_test.go
+++ b/sfuServer/internal/provider/scaleway/scaleway_test.go
@@ -31,6 +31,19 @@ func TestCreateServerRequestAttachesConfiguredSecurityGroup(t *testing.T) {
 	if req.DynamicIPRequired == nil || !*req.DynamicIPRequired {
 		t.Fatal("dynamic IP must be requested")
 	}
+	root := req.Volumes["0"]
+	if root == nil {
+		t.Fatal("root volume must be configured")
+	}
+	if root.Size == nil || *root.Size != scw.GB*10 {
+		t.Fatalf("root volume size = %v, want 10 GB", root.Size)
+	}
+	if root.VolumeType != "l_ssd" {
+		t.Fatalf("root volume type = %q, want l_ssd", root.VolumeType)
+	}
+	if root.Boot == nil || !*root.Boot {
+		t.Fatal("root volume must be bootable")
+	}
 }
 
 func TestNewRequiresSecurityGroup(t *testing.T) {


### PR DESCRIPTION
## Summary
- explicitly request a 10 GB boot volume for ephemeral SFU workers
- use local SSD storage so terminating the Instance removes the root volume with it
- cover size, type, and boot flags in the Scaleway request test

## Why
The OpenSpec rollout baseline sets a 10 GB root-volume cost guardrail and requires worker storage to be deleted on termination. `DEV1-S` supports 10 GB local volumes, and the adapter already terminates workers instead of stopping them.

## Validation
- `go test ./...`
- checked against the current Scaleway `fr-par-1` `DEV1-S` volume constraints (10 GB is accepted)

## Dependency
Stacked on #154 because both changes extend the same tested Scaleway request builder. Once #154 is merged, this PR can be retargeted to `main` without carrying duplicate changes.
