### PR TITLE
feat(sfu): expose autoscaler lifecycle metrics

### DIFF
--- a/sfuServer/cmd/controlplane/main.go
+++ b/sfuServer/cmd/controlplane/main.go
@@ -127,6 +127,7 @@ func wireAutoscaler(cp *controlplane.ControlPlane) error {
 		ManagedTag: getEnv("SFU_MANAGED_TAG", "sfu-worker"),
 	})
 	cp.SetProvisioner(prov)
+	http.Handle("/metrics", prov.MetricsHandler())
 
 	ctx := context.Background()
 	go prov.Run(ctx) // startup-timeout reaping (task 4.3)

--- a/sfuServer/internal/autoscaler/metrics.go
+++ b/sfuServer/internal/autoscaler/metrics.go
@@ -1,0 +1,106 @@
+package autoscaler
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"whip-server/internal/models"
+)
+
+// WorkerRuntime is the current runtime of one non-terminal worker. Labels are
+// intentionally limited to the bounded live-worker set to avoid unbounded
+// Prometheus cardinality from historical workers.
+type WorkerRuntime struct {
+	SFUID   string
+	State   models.WorkerState
+	Seconds float64
+}
+
+// MetricsSnapshot is a testable, provider-neutral view of autoscaler SLIs.
+type MetricsSnapshot struct {
+	ActiveWorkers               int
+	RoomReadinessFailures       uint64
+	OrphanCleanups              uint64
+	ProvisioningDurationCount   uint64
+	ProvisioningDurationSeconds float64
+	TerminatedRuntimeCount      uint64
+	TerminatedRuntimeSeconds    float64
+	CurrentWorkerRuntime        []WorkerRuntime
+}
+
+// MetricsSnapshot returns autoscaler metrics. Durable lifecycle metrics are
+// reconstructed from the store so a control-plane restart does not erase
+// provisioning and terminated-runtime observations.
+func (p *Provisioner) MetricsSnapshot() MetricsSnapshot {
+	now := p.now()
+	snapshot := MetricsSnapshot{
+		RoomReadinessFailures: p.readinessFailures.Load(),
+		OrphanCleanups:        p.orphanCleanups.Load(),
+	}
+	for _, worker := range p.store.ListWorkers() {
+		if worker.ReadyAt != nil && !worker.CreatedAt.IsZero() && !worker.ReadyAt.Before(worker.CreatedAt) {
+			snapshot.ProvisioningDurationCount++
+			snapshot.ProvisioningDurationSeconds += worker.ReadyAt.Sub(worker.CreatedAt).Seconds()
+		}
+
+		if worker.State == models.WorkerTerminated || worker.State == models.WorkerFailed {
+			if worker.TerminatedAt != nil && !worker.CreatedAt.IsZero() && !worker.TerminatedAt.Before(worker.CreatedAt) {
+				snapshot.TerminatedRuntimeCount++
+				snapshot.TerminatedRuntimeSeconds += worker.TerminatedAt.Sub(worker.CreatedAt).Seconds()
+			}
+			continue
+		}
+
+		snapshot.ActiveWorkers++
+		if !worker.CreatedAt.IsZero() && !now.Before(worker.CreatedAt) {
+			snapshot.CurrentWorkerRuntime = append(snapshot.CurrentWorkerRuntime, WorkerRuntime{
+				SFUID:   worker.SFUID,
+				State:   worker.State,
+				Seconds: now.Sub(worker.CreatedAt).Seconds(),
+			})
+		}
+	}
+	sort.Slice(snapshot.CurrentWorkerRuntime, func(i, j int) bool {
+		return snapshot.CurrentWorkerRuntime[i].SFUID < snapshot.CurrentWorkerRuntime[j].SFUID
+	})
+	return snapshot
+}
+
+// MetricsHandler exposes Prometheus text-format metrics without adding a
+// runtime dependency to the control-plane image.
+func (p *Provisioner) MetricsHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Only GET is supported", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+		_, _ = fmt.Fprint(w, renderPrometheus(p.MetricsSnapshot()))
+	})
+}
+
+func renderPrometheus(m MetricsSnapshot) string {
+	var b strings.Builder
+	metric(&b, "ochocast_sfu_active_workers", "gauge", "Current number of non-terminal autoscaled SFU workers.", float64(m.ActiveWorkers))
+	metric(&b, "ochocast_sfu_room_readiness_failures_total", "counter", "Room provisioning attempts that failed to obtain ready autoscaled SFU capacity.", float64(m.RoomReadinessFailures))
+	metric(&b, "ochocast_sfu_orphan_cleanup_total", "counter", "Tagged orphan SFU resources deleted by reconciliation.", float64(m.OrphanCleanups))
+	metric(&b, "ochocast_sfu_provisioning_duration_seconds_sum", "gauge", "Cumulative cold-start duration for workers that reached ready.", m.ProvisioningDurationSeconds)
+	metric(&b, "ochocast_sfu_provisioning_duration_seconds_count", "gauge", "Workers that reached ready and contributed a provisioning duration.", float64(m.ProvisioningDurationCount))
+	metric(&b, "ochocast_sfu_terminated_worker_runtime_seconds_sum", "gauge", "Cumulative runtime of terminated autoscaled SFU workers.", m.TerminatedRuntimeSeconds)
+	metric(&b, "ochocast_sfu_terminated_worker_runtime_seconds_count", "gauge", "Terminated workers that contributed a runtime observation.", float64(m.TerminatedRuntimeCount))
+	for _, worker := range m.CurrentWorkerRuntime {
+		fmt.Fprintf(&b, "ochocast_sfu_worker_runtime_seconds{sfu_id=%q,state=%q} %s\n", worker.SFUID, worker.State, number(worker.Seconds))
+	}
+	return b.String()
+}
+
+func metric(b *strings.Builder, name, metricType, help string, value float64) {
+	fmt.Fprintf(b, "# HELP %s %s\n# TYPE %s %s\n%s %s\n", name, help, name, metricType, name, number(value))
+}
+
+func number(value float64) string {
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}

--- a/sfuServer/internal/autoscaler/metrics_test.go
+++ b/sfuServer/internal/autoscaler/metrics_test.go
@@ -1,0 +1,72 @@
+package autoscaler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"whip-server/internal/models"
+	"whip-server/internal/provider"
+)
+
+func TestMetricsSnapshotCoversAutoscalerSLIs(t *testing.T) {
+	fake := provider.NewFake()
+	p, store := newTestProvisioner(t, fake, 1)
+	rec, err := p.EnsureCapacity(context.Background(), "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := rec.CreatedAt
+	readyAt := created.Add(12 * time.Second)
+	rec.State = models.WorkerRegistered
+	if rec, err = store.UpsertWorker(rec); err != nil {
+		t.Fatal(err)
+	}
+	rec.State = models.WorkerReady
+	rec.ReadyAt = &readyAt
+	if _, err = store.UpsertWorker(rec); err != nil {
+		t.Fatal(err)
+	}
+	p.now = func() time.Time { return created.Add(42 * time.Second) }
+
+	// A rejected second room is a readiness failure and does not create a worker.
+	if _, err := p.EnsureCapacity(context.Background(), "room-2"); err == nil {
+		t.Fatal("expected budget failure")
+	}
+
+	snapshot := p.MetricsSnapshot()
+	if snapshot.ActiveWorkers != 1 || snapshot.RoomReadinessFailures != 1 {
+		t.Fatalf("unexpected counts: %+v", snapshot)
+	}
+	if snapshot.ProvisioningDurationCount != 1 || snapshot.ProvisioningDurationSeconds != 12 {
+		t.Fatalf("unexpected provisioning duration: %+v", snapshot)
+	}
+	if len(snapshot.CurrentWorkerRuntime) != 1 || snapshot.CurrentWorkerRuntime[0].Seconds != 42 {
+		t.Fatalf("unexpected runtime: %+v", snapshot.CurrentWorkerRuntime)
+	}
+}
+
+func TestMetricsHandlerRendersPrometheusText(t *testing.T) {
+	p, _ := newTestProvisioner(t, provider.NewFake(), 1)
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	res := httptest.NewRecorder()
+	p.MetricsHandler().ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", res.Code)
+	}
+	for _, name := range []string{
+		"ochocast_sfu_active_workers",
+		"ochocast_sfu_room_readiness_failures_total",
+		"ochocast_sfu_orphan_cleanup_total",
+		"ochocast_sfu_provisioning_duration_seconds_sum",
+		"ochocast_sfu_terminated_worker_runtime_seconds_sum",
+	} {
+		if !strings.Contains(res.Body.String(), name) {
+			t.Errorf("metric %s missing from:\n%s", name, res.Body.String())
+		}
+	}
+}

--- a/sfuServer/internal/autoscaler/provisioner.go
+++ b/sfuServer/internal/autoscaler/provisioner.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"whip-server/internal/lifecycle"
@@ -74,6 +75,11 @@ type Provisioner struct {
 
 	// now is the clock, overridable in tests.
 	now func() time.Time
+
+	// Counters are process-local Prometheus counters. Lifecycle-derived gauges
+	// and duration summaries are rebuilt from the durable store on every scrape.
+	readinessFailures atomic.Uint64
+	orphanCleanups    atomic.Uint64
 }
 
 // New builds a Provisioner. MaxWorkers < 1 is clamped to 1 and an unset
@@ -115,11 +121,13 @@ func (p *Provisioner) EnsureCapacity(ctx context.Context, roomID string) (models
 
 	// 2. Budget cap on live workers across the environment.
 	if p.liveWorkerCount() >= p.cfg.MaxWorkers {
+		p.readinessFailures.Add(1)
 		return models.WorkerRecord{}, ErrBudgetExceeded
 	}
 
 	// 3. Move the room into provisioning (idempotent; safe if already provisioning).
 	if _, _, err := p.store.EnsureRoomProvisioning(roomID); err != nil {
+		p.readinessFailures.Add(1)
 		return models.WorkerRecord{}, err
 	}
 
@@ -134,6 +142,7 @@ func (p *Provisioner) EnsureCapacity(ctx context.Context, roomID string) (models
 		ImageTag: p.cfg.ImageTag,
 	}
 	if _, err := p.store.UpsertWorker(rec); err != nil {
+		p.readinessFailures.Add(1)
 		return models.WorkerRecord{}, err
 	}
 
@@ -148,6 +157,7 @@ func (p *Provisioner) EnsureCapacity(ctx context.Context, roomID string) (models
 	}
 	w, err := p.prov.CreateWorker(ctx, spec)
 	if err != nil {
+		p.readinessFailures.Add(1)
 		// Mark worker and room failed; the record is kept (not deleted) so
 		// reconciliation can confirm no cloud resource leaked.
 		rec.State = models.WorkerFailed
@@ -166,6 +176,7 @@ func (p *Provisioner) EnsureCapacity(ctx context.Context, roomID string) (models
 	}
 	saved, err := p.store.UpsertWorker(rec)
 	if err != nil {
+		p.readinessFailures.Add(1)
 		return models.WorkerRecord{}, err
 	}
 	return saved, nil
@@ -306,6 +317,7 @@ func (p *Provisioner) ReapStartupTimeouts(ctx context.Context) int {
 		if w.RoomID != "" {
 			_, _ = p.store.Upsert(w.RoomID, models.RoomFailed, "sfu startup timeout")
 		}
+		p.readinessFailures.Add(1)
 		reaped++
 	}
 	return reaped
@@ -419,6 +431,7 @@ func (p *Provisioner) CleanupOrphans(ctx context.Context) (int, error) {
 		}
 		deleted++
 	}
+	p.orphanCleanups.Add(uint64(deleted))
 	return deleted, nil
 }
 

--- a/sfuServer/internal/lifecycle/store.go
+++ b/sfuServer/internal/lifecycle/store.go
@@ -259,6 +259,9 @@ func (s *Store) UpsertWorker(w models.WorkerRecord) (models.WorkerRecord, error)
 			return prev, fmt.Errorf("invalid worker transition %s -> %s for sfu %s", prev.State, w.State, w.SFUID)
 		}
 		w.CreatedAt = prev.CreatedAt
+		if w.ReadyAt == nil {
+			w.ReadyAt = prev.ReadyAt
+		}
 	} else {
 		w.CreatedAt = now
 	}

--- a/sfuServer/internal/models/shared.go
+++ b/sfuServer/internal/models/shared.go
@@ -98,6 +98,7 @@ type WorkerRecord struct {
 	Reason             string            `json:"reason,omitempty"`        // why it entered a failed/terminated state
 	CreatedAt          time.Time         `json:"created_at"`              // creation time
 	UpdatedAt          time.Time         `json:"updated_at"`              // last state change
+	ReadyAt            *time.Time        `json:"ready_at,omitempty"`      // first healthy heartbeat; used for provisioning SLI
 	LastHeartbeat      time.Time         `json:"last_heartbeat_at"`       // last heartbeat time
 	TerminatedAt       *time.Time        `json:"terminated_at,omitempty"` // termination status
 	Metadata           map[string]string `json:"metadata,omitempty"`      // provider-specific fields (zone, volume ids, ...)

--- a/sfuServer/pkg/controlplane/controlplane.go
+++ b/sfuServer/pkg/controlplane/controlplane.go
@@ -1099,6 +1099,10 @@ func (cp *ControlPlane) promoteWorker(sfuID string, healthy bool) {
 			return
 		}
 		rec.State = models.WorkerReady
+		if rec.ReadyAt == nil {
+			now := time.Now().UTC()
+			rec.ReadyAt = &now
+		}
 	default:
 		return // ready/draining/failed/terminated: nothing to advance
 	}

--- a/sfuServer/pkg/controlplane/controlplane_test.go
+++ b/sfuServer/pkg/controlplane/controlplane_test.go
@@ -195,8 +195,8 @@ func TestColdStartReadinessLoop(t *testing.T) {
 	if err := cp.UpdateMetrics(&models.SFUMetrics{SFUID: sfuID, ServerURL: "http://1.2.3.4:8080", CPU: 0.1, Memory: 0.1}); err != nil {
 		t.Fatal(err)
 	}
-	if w, _ := cp.LifecycleStore().GetWorker(sfuID); w.State != models.WorkerReady {
-		t.Fatalf("after healthy heartbeat, worker state = %s, want ready", w.State)
+	if w, _ := cp.LifecycleStore().GetWorker(sfuID); w.State != models.WorkerReady || w.ReadyAt == nil {
+		t.Fatalf("after healthy heartbeat, worker must be ready with ready_at: %+v", w)
 	}
 	if rl, _ := cp.LifecycleStore().Get("room-1"); rl.State != models.RoomReady {
 		t.Fatalf("room state = %s, want ready", rl.State)


### PR DESCRIPTION
## Summary
- expose a Prometheus-compatible `/metrics` endpoint from the SFU control-plane
- report active worker count, room readiness failures, orphan cleanup count, provisioning duration, and worker runtime
- persist the first `ready_at` timestamp so provisioning-duration observations survive control-plane restarts
- cover metrics rendering and the real register/healthy-heartbeat readiness transition

## Metrics
- `ochocast_sfu_active_workers`
- `ochocast_sfu_room_readiness_failures_total`
- `ochocast_sfu_orphan_cleanup_total`
- `ochocast_sfu_provisioning_duration_seconds_{sum,count}`
- `ochocast_sfu_terminated_worker_runtime_seconds_{sum,count}`
- `ochocast_sfu_worker_runtime_seconds{sfu_id,state}` for the bounded set of live workers

## Validation
- `go test ./...`
- `go vet ./...`

## OpenSpec
Covers validation/rollout task 8.6.

## Dependency
Stacked on #155 so terminated-worker runtime metrics include the idle scale-down lifecycle. Once #155 is merged, this PR can be retargeted to `main`.
