### PR TITLE
fix(sfu): expose public WHIP URLs behind ingress

### DIFF
--- a/sfuServer/cmd/controlplane/main.go
+++ b/sfuServer/cmd/controlplane/main.go
@@ -24,6 +24,9 @@ func main() {
 
 	// Create control plane instance
 	cp := controlplane.NewControlPlane(maxFanout, rebalanceThreshold)
+	if err := cp.SetPublicURL(os.Getenv("SFU_CONTROL_PLANE_URL")); err != nil {
+		log.Fatalf("[CP] invalid public URL: %v", err)
+	}
 
 	// Enable on-demand SFU autoscaling when Scaleway credentials are present.
 	// Without them the control-plane behaves as before (hard-fails room creation

--- a/sfuServer/pkg/controlplane/controlplane.go
+++ b/sfuServer/pkg/controlplane/controlplane.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -98,6 +99,10 @@ type ControlPlane struct {
 	// configured, in which case room creation hard-fails on "no active SFUs" as
 	// before.
 	provisioner capacityEnsurer
+
+	// Externally reachable TLS endpoint used in streamer-facing WHIP URLs.
+	// Empty falls back to the host and forwarding headers of the HTTP request.
+	publicURL string
 }
 
 // capacityEnsurer provisions on-demand SFU capacity for a room. Implemented by
@@ -115,6 +120,22 @@ func (cp *ControlPlane) SetProvisioner(p capacityEnsurer) {
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
 	cp.provisioner = p
+}
+
+// SetPublicURL configures the externally reachable control-plane base URL.
+func (cp *ControlPlane) SetPublicURL(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("invalid control-plane public URL %q", raw)
+	}
+	cp.mu.Lock()
+	cp.publicURL = strings.TrimRight(raw, "/")
+	cp.mu.Unlock()
+	return nil
 }
 
 // LifecycleStore returns the control-plane's persistent lifecycle store so the
@@ -2119,18 +2140,27 @@ func (cp *ControlPlane) HandleRoomExists(w http.ResponseWriter, r *http.Request)
 
 	// Room exists - get info from topology
 	roomKey := topology.Key
-	controlPlaneURL := fmt.Sprintf("http://localhost:%s", "8090") // Use control plane URL
 	cp.mu.RUnlock()
 
-	// Room exists - return WHIP URL
-	whipURL := fmt.Sprintf("%s/whip?room_id=%s&key=%s", controlPlaneURL, roomID, roomKey)
+	state := models.RoomReady // legacy rooms without lifecycle records
+	if cp.roomState != nil {
+		if room, ok := cp.roomState.Get(roomID); ok {
+			state = room.State
+		}
+	}
+	ready := state == models.RoomReady
+	response := map[string]interface{}{
+		"exists":  true,
+		"room_id": roomID,
+		"state":   string(state),
+		"ready":   ready,
+	}
+	if ready {
+		response["whip_url"] = cp.publicWHIPURL(r, roomID, roomKey)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"exists":   true,
-		"room_id":  roomID,
-		"whip_url": whipURL,
-	})
+	json.NewEncoder(w).Encode(response)
 	log.Printf("[CP-EXISTS] Room %s exists", roomID)
 }
 
@@ -2306,7 +2336,37 @@ func (cp *ControlPlane) HandleRoomStatus(w http.ResponseWriter, r *http.Request)
 		resp["reason"] = reason
 	}
 	if ready && key != "" {
-		resp["whip_url"] = fmt.Sprintf("http://localhost:%s/whip?room_id=%s&key=%s", "8090", roomID, key)
+		resp["whip_url"] = cp.publicWHIPURL(r, roomID, key)
 	}
 	json.NewEncoder(w).Encode(resp)
+}
+
+func (cp *ControlPlane) publicWHIPURL(r *http.Request, roomID, key string) string {
+	cp.mu.RLock()
+	base := cp.publicURL
+	cp.mu.RUnlock()
+	if base == "" {
+		scheme := firstForwardedValue(r.Header.Get("X-Forwarded-Proto"))
+		if scheme == "" {
+			if r.TLS != nil {
+				scheme = "https"
+			} else {
+				scheme = "http"
+			}
+		}
+		host := firstForwardedValue(r.Header.Get("X-Forwarded-Host"))
+		if host == "" {
+			host = r.Host
+		}
+		base = scheme + "://" + host
+	}
+	query := url.Values{"room_id": {roomID}, "key": {key}}
+	return strings.TrimRight(base, "/") + "/whip?" + query.Encode()
+}
+
+func firstForwardedValue(value string) string {
+	if first, _, ok := strings.Cut(value, ","); ok {
+		return strings.TrimSpace(first)
+	}
+	return strings.TrimSpace(value)
 }

--- a/sfuServer/pkg/controlplane/controlplane_test.go
+++ b/sfuServer/pkg/controlplane/controlplane_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"testing"
 	"time"
@@ -120,6 +121,79 @@ func TestRoomStatusProvisioningThenReady(t *testing.T) {
 	// Unknown room: 404.
 	if code, _ := roomStatus(t, cp, "nope"); code != http.StatusNotFound {
 		t.Fatalf("unknown room status = %d, want 404", code)
+	}
+}
+
+func TestRoomEndpointsExposeConfiguredPublicWHIPURL(t *testing.T) {
+	cp := newTestCP(t)
+	cp.SetProvisioner(&stubEnsurer{called: make(chan string, 1)})
+	if err := cp.SetPublicURL("https://sfu-staging.example.test/"); err != nil {
+		t.Fatal(err)
+	}
+	key, _, err := cp.CreateRoom("room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cp.roomState.Upsert("room-1", models.RoomReady, ""); err != nil {
+		t.Fatal(err)
+	}
+	want := "https://sfu-staging.example.test/whip?key=" + url.QueryEscape(key) + "&room_id=room-1"
+
+	statusCode, status := roomStatus(t, cp, "room-1")
+	if statusCode != http.StatusOK || status["whip_url"] != want {
+		t.Fatalf("room status=%d body=%+v, want whip_url=%s", statusCode, status, want)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/room/exists?room_id=room-1", nil)
+	res := httptest.NewRecorder()
+	cp.HandleRoomExists(res, req)
+	var exists map[string]interface{}
+	if err := json.NewDecoder(res.Body).Decode(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if exists["whip_url"] != want {
+		t.Fatalf("room exists body=%+v, want whip_url=%s", exists, want)
+	}
+}
+
+func TestRoomExistsDoesNotExposeWHIPURLWhileProvisioning(t *testing.T) {
+	cp := newTestCP(t)
+	cp.SetProvisioner(&stubEnsurer{called: make(chan string, 1)})
+	if _, _, err := cp.CreateRoom("room-1"); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/room/exists?room_id=room-1", nil)
+	res := httptest.NewRecorder()
+	cp.HandleRoomExists(res, req)
+	var body map[string]interface{}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["state"] != "provisioning" || body["ready"] != false {
+		t.Fatalf("unexpected lifecycle response: %+v", body)
+	}
+	if _, ok := body["whip_url"]; ok {
+		t.Fatalf("WHIP URL exposed before readiness: %+v", body)
+	}
+}
+
+func TestPublicWHIPURLUsesForwardedIngressHeaders(t *testing.T) {
+	cp := newTestCP(t)
+	req := httptest.NewRequest(http.MethodGet, "/room/status", nil)
+	req.Header.Set("X-Forwarded-Proto", "https, http")
+	req.Header.Set("X-Forwarded-Host", "sfu.example.test, ingress.internal")
+	want := "https://sfu.example.test/whip?key=secret&room_id=room+with+spaces"
+	if got := cp.publicWHIPURL(req, "room with spaces", "secret"); got != want {
+		t.Fatalf("publicWHIPURL=%s, want %s", got, want)
+	}
+}
+
+func TestSetPublicURLRejectsInvalidURL(t *testing.T) {
+	cp := newTestCP(t)
+	for _, value := range []string{"localhost:8090", "ftp://sfu.example.test"} {
+		if err := cp.SetPublicURL(value); err == nil {
+			t.Fatalf("SetPublicURL(%q) should fail", value)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace hardcoded `http://localhost:8090` WHIP URLs with the configured public control-plane URL
- fall back to standard ingress forwarding headers when no explicit public URL is configured
- URL-encode room IDs and keys
- stop `/room/exists` from exposing WHIP instructions before lifecycle readiness

## Why
The staging/production control-plane runs behind a TLS ingress. Returning localhost makes an existing ready room unusable from the frontend and blocks the cold-start rollout validation.

## Configuration
Consumes the existing `SFU_CONTROL_PLANE_URL` value already wired by ops PR #45.

## Validation
- `go test ./...`
- `go vet ./...`
- coverage for configured URL, ingress headers, invalid configuration, and provisioning-state gating
