### PR TITLE
ci(sfu): run Go tests and vet on pull requests

### DIFF
--- a/.github/workflows/verify-before-merge.yml
+++ b/.github/workflows/verify-before-merge.yml
@@ -118,3 +118,22 @@ jobs:
       - name: Run unit tests
         run: |
           npm test
+
+  test-sfu-go:
+    name: test-sfu-go
+    runs-on: self-hosted
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: sfuServer
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Go from sfuServer/go.mod
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: sfuServer/go.mod
+          cache-dependency-path: sfuServer/go.sum
+      - name: Run SFU tests
+        run: go test ./...
+      - name: Run SFU vet
+        run: go vet ./...

--- a/.github/workflows/verify-before-merge.yml
+++ b/.github/workflows/verify-before-merge.yml
@@ -129,7 +129,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Go from sfuServer/go.mod
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: sfuServer/go.mod
           cache-dependency-path: sfuServer/go.sum


### PR DESCRIPTION
## Summary
- add a dedicated `test-sfu-go` job to the main pull-request workflow
- install the Go version declared by `sfuServer/go.mod`
- run `go test ./...` and `go vet ./...` from `sfuServer`
- keep action dependencies pinned to full commit SHAs

## Why
The current green PR checks compile/test frontend and backend but do not execute the SFU Go test suite. The autoscaling rollout now relies on those tests for provider requests, lifecycle transitions, cleanup, and observability.

## Validation
- workflow YAML parsed with `yq`
- `go test ./...`
- `go vet ./...`
