### PR TITLE
fix(sfu): read worker public IPv4 from Scaleway metadata JSON

### DIFF
--- a/sfuServer/deploy/bootstrap_test.go
+++ b/sfuServer/deploy/bootstrap_test.go
@@ -61,6 +61,8 @@ func TestWorkerConfigRender(t *testing.T) {
 		"export SFU_REGISTRY_PASSWORD='pa'\"'\"'ss; echo unsafe'",
 		"docker run",
 		"-e TURN_PASSWORD=\"${TURN_PASSWORD:-}\"",
+		"conf?format=json",
+		".public_ips_v4[0].address // .public_ip.address // empty",
 	}
 	for _, want := range wants {
 		if !strings.Contains(rendered, want) {
@@ -69,5 +71,8 @@ func TestWorkerConfigRender(t *testing.T) {
 	}
 	if strings.Count(rendered, "#!/usr/bin/env bash") != 1 {
 		t.Fatalf("rendered user-data must contain exactly one shebang")
+	}
+	if strings.Contains(rendered, `$1 == "PUBLIC_IP"`) {
+		t.Fatal("rendered user-data must not parse the legacy PUBLIC_IP table")
 	}
 }

--- a/sfuServer/deploy/scaleway-worker-bootstrap.sh
+++ b/sfuServer/deploy/scaleway-worker-bootstrap.sh
@@ -28,8 +28,15 @@ detect_public_ip() {
     return
   fi
 
-  if command -v curl >/dev/null 2>&1; then
-    PUBLIC_IP="$(curl -fsS --max-time 2 http://169.254.42.42/conf 2>/dev/null | awk -F= '$1 == "PUBLIC_IP" { print $2; exit }' || true)"
+  # PUBLIC_IP in the legacy key/value response is now a shell-quoted table
+  # when an Instance uses the multi-IP network stack. Consume the structured
+  # metadata response instead and select the first public IPv4 address.
+  if command -v curl >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    PUBLIC_IP="$(
+      curl -fsS --max-time 5 'http://169.254.42.42/conf?format=json' 2>/dev/null \
+        | jq -r '.public_ips_v4[0].address // .public_ip.address // empty' \
+        || true
+    )"
   fi
 }
 
@@ -41,13 +48,13 @@ install_docker() {
   if command -v apt-get >/dev/null 2>&1; then
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install -y ca-certificates curl docker.io
+    apt-get install -y ca-certificates curl docker.io jq
     systemctl enable --now docker
     return
   fi
 
   if command -v apk >/dev/null 2>&1; then
-    apk add --no-cache docker
+    apk add --no-cache ca-certificates curl docker jq
     rc-update add docker default || true
     service docker start || true
     return


### PR DESCRIPTION
## Summary
- read the worker public IPv4 from the structured Scaleway metadata JSON
- install `jq` in the worker bootstrap
- reject the legacy `PUBLIC_IP` table parsing through a regression assertion

## Staging evidence
The first live worker registered with `PUBLIC_IP='ADDRESS DYNAMIC FAMILY ...'` because the legacy metadata field is now a table. The JSON endpoint returned `public_ips_v4[0].address=212.47.232.50`. The defective test worker was terminated and its dynamic IP released.

## Validation
- `shellcheck deploy/scaleway-worker-bootstrap.sh`
- `go test ./deploy ./internal/provider/scaleway ./internal/autoscaler` (Go 1.26 container)