### PR TITLE
fix(sfu): make OBS WHIP publishing work in staging

### DIFF
--- a/frontend/src/pages/liveTrack/liveTrack.tsx
+++ b/frontend/src/pages/liveTrack/liveTrack.tsx
@@ -120,36 +120,10 @@ const LiveTrack = () => {
     };
   }, [trackId]);
 
-  // Discover SFU endpoint from control plane
-  const discoverSFU = useCallback(
-    async (roomId: string) => {
-      try {
-        const discoveryUrl = `${CONTROL_PLANE_URL}/viewer?room_id=${roomId}`;
-        console.log('Discovering SFU from control plane:', discoveryUrl);
-
-        const response = await fetch(discoveryUrl);
-        if (!response.ok) {
-          throw new Error(
-            `Discovery failed: ${response.status} ${response.statusText}`,
-          );
-        }
-
-        const data = await response.json();
-        console.log('SFU discovery response:', data);
-
-        if (!data.sfu_url) {
-          throw new Error('No SFU URL returned from control plane');
-        }
-
-        // Return the direct SFU URL for viewer endpoint
-        const sfuViewerUrl = `${data.sfu_url}/viewer?room_id=${roomId}`;
-        console.log('Discovered SFU viewer URL:', sfuViewerUrl);
-        return sfuViewerUrl;
-      } catch (error) {
-        console.error('Failed to discover SFU:', error);
-        throw error;
-      }
-    },
+  // Keep browser signaling on the public TLS control-plane endpoint. Workers
+  // use private HTTP URLs that browsers cannot fetch from an HTTPS page.
+  const getViewerUrl = useCallback(
+    (roomId: string) => `${CONTROL_PLANE_URL}/viewer?room_id=${roomId}`,
     [CONTROL_PLANE_URL],
   );
 
@@ -523,27 +497,15 @@ const LiveTrack = () => {
         peerConnection?.addEventListener('icegatheringstatechange', checkState);
       });
 
-      Logger.info('Connection', 'Discovering SFU');
-
-      // ============ DISCOVER SFU ============
-      let sfuViewerUrl: string;
-      try {
-        sfuViewerUrl = await discoverSFU(trackId!);
-      } catch (error) {
-        throw new Error(
-          `Failed to discover SFU: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
+      const viewerUrl = getViewerUrl(trackId!);
 
       // ============ SEND OFFER TO SFU ============
       if (!peerConnection.localDescription?.sdp) {
         throw new Error('Local description is not set');
       }
 
-      Logger.info('Connection', 'Sending SDP to SFU');
-      const response = await fetch(sfuViewerUrl, {
+      Logger.info('Connection', 'Sending SDP through control plane');
+      const response = await fetch(viewerUrl, {
         method: 'POST',
         body: peerConnection.localDescription.sdp,
         headers: { 'Content-Type': 'application/sdp' },
@@ -575,7 +537,7 @@ const LiveTrack = () => {
       setIsConnecting(false);
       throw err; // Re-throw for reconnection handler
     }
-  }, [discoverSFU, trackId, handleIncomingTrack, attemptReconnect]);
+  }, [getViewerUrl, trackId, handleIncomingTrack, attemptReconnect]);
 
   if (track?.closed) {
     navigate(`/events/${track?.event.id}/tracks`);

--- a/sfuServer/.env.example
+++ b/sfuServer/.env.example
@@ -111,6 +111,11 @@ CASCADE_AUTH_KEY=your-secure-cascade-key-here
 # Only effective if TURN_SERVER is configured
 # ICE_RELAY_ONLY=false
 
+# Bound every direct ICE/UDP socket to the matching firewall range.
+# Both values must be set together when direct UDP is enabled.
+# ICE_UDP_PORT_MIN=50000
+# ICE_UDP_PORT_MAX=50100
+
 # ============================================================================
 # EXAMPLE CONFIGURATIONS
 # ============================================================================

--- a/sfuServer/cmd/controlplane/main.go
+++ b/sfuServer/cmd/controlplane/main.go
@@ -134,6 +134,8 @@ func wireAutoscaler(cp *controlplane.ControlPlane) error {
 		SFUPort:         getEnv("SFU_WORKER_PORT", "8090"),
 		ICERelayOnly:    envBool("ICE_RELAY_ONLY", true),
 		EnableICETCP:    envBool("ENABLE_ICE_TCP", false),
+		ICEUDPPortMin:   os.Getenv("ICE_UDP_PORT_MIN"),
+		ICEUDPPortMax:   os.Getenv("ICE_UDP_PORT_MAX"),
 		STUNServers:     os.Getenv("STUN_SERVERS"),
 		TURNServer:      os.Getenv("TURN_SERVER"),
 		TURNUsername:    os.Getenv("TURN_USERNAME"),

--- a/sfuServer/cmd/controlplane/main.go
+++ b/sfuServer/cmd/controlplane/main.go
@@ -49,10 +49,11 @@ func main() {
 	http.HandleFunc("/room/exists", corsMiddleware(cp.HandleRoomExists))
 	http.HandleFunc("/room/status", corsMiddleware(cp.HandleRoomStatus)) // Poll provisioning -> ready/failed
 	http.HandleFunc("/room/viewers", corsMiddleware(cp.HandleRoomViewerCount))
-	http.HandleFunc("/whip", corsMiddleware(cp.HandleWHIP))                  // Proxy WHIP to ingestion SFU
-	http.HandleFunc("/viewer", corsMiddleware(cp.HandleViewer))              // Proxy viewer to optimal SFU
-	http.HandleFunc("/recorder", corsMiddleware(cp.HandleRecorder))          // Return ingestion SFU for recorder
-	http.HandleFunc("/stream-status", corsMiddleware(cp.HandleStreamStatus)) // Check stream status
+	http.HandleFunc("/whip", corsMiddleware(cp.HandleWHIP))                   // Proxy WHIP to ingestion SFU
+	http.HandleFunc("/viewer", corsMiddleware(cp.HandleViewer))               // Proxy viewer to optimal SFU
+	http.HandleFunc("/recorder", corsMiddleware(cp.HandleRecorder))           // Return ingestion SFU for recorder
+	http.HandleFunc("/stream-status", corsMiddleware(cp.HandleStreamStatus))  // Check stream status
+	http.HandleFunc("/whip/resource/", corsMiddleware(cp.HandleWHIPResource)) // Terminate a WHIP publishing session
 
 	log.Printf("Control Plane listening on :%s", port)
 	log.Printf("Configuration: maxFanout=%d, rebalanceThreshold=%.2f", maxFanout, rebalanceThreshold)
@@ -68,6 +69,7 @@ func corsMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		w.Header().Set("Access-Control-Expose-Headers", "Location, Link")
 
 		// Handle preflight requests
 		if r.Method == http.MethodOptions {

--- a/sfuServer/deploy/bootstrap.go
+++ b/sfuServer/deploy/bootstrap.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	_ "embed"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -23,6 +24,8 @@ type WorkerConfig struct {
 	SFUPort         string
 	ICERelayOnly    bool
 	EnableICETCP    bool
+	ICEUDPPortMin   string
+	ICEUDPPortMax   string
 	STUNServers     string
 	TURNServer      string
 	TURNUsername    string
@@ -48,6 +51,16 @@ func (c WorkerConfig) Validate() error {
 	if c.ICERelayOnly {
 		if c.TURNServer == "" || c.TURNUsername == "" || c.TURNPassword == "" {
 			return fmt.Errorf("TURN_SERVER, TURN_USERNAME and TURN_PASSWORD are required when ICE_RELAY_ONLY=true")
+		}
+	}
+	if c.ICEUDPPortMin != "" || c.ICEUDPPortMax != "" {
+		if c.ICEUDPPortMin == "" || c.ICEUDPPortMax == "" {
+			return fmt.Errorf("ICE_UDP_PORT_MIN and ICE_UDP_PORT_MAX must be set together")
+		}
+		minPort, minErr := strconv.ParseUint(c.ICEUDPPortMin, 10, 16)
+		maxPort, maxErr := strconv.ParseUint(c.ICEUDPPortMax, 10, 16)
+		if minErr != nil || maxErr != nil || minPort == 0 || maxPort == 0 || maxPort < minPort {
+			return fmt.Errorf("invalid ICE UDP port range %q-%q", c.ICEUDPPortMin, c.ICEUDPPortMax)
 		}
 	}
 	return nil
@@ -80,6 +93,8 @@ func (c WorkerConfig) Render(sfuID, roomID string) string {
 		{"CONTROL_PLANE_URL", c.ControlPlaneURL},
 		{"ICE_RELAY_ONLY", fmt.Sprintf("%t", c.ICERelayOnly)},
 		{"ENABLE_ICE_TCP", fmt.Sprintf("%t", c.EnableICETCP)},
+		{"ICE_UDP_PORT_MIN", c.ICEUDPPortMin},
+		{"ICE_UDP_PORT_MAX", c.ICEUDPPortMax},
 		{"STUN_SERVERS", c.STUNServers},
 		{"TURN_SERVER", c.TURNServer},
 		{"TURN_USERNAME", c.TURNUsername},

--- a/sfuServer/deploy/bootstrap_test.go
+++ b/sfuServer/deploy/bootstrap_test.go
@@ -13,6 +13,8 @@ func TestWorkerConfigValidate(t *testing.T) {
 		TURNServer:      "turn:turn.example.com:3478",
 		TURNUsername:    "user",
 		TURNPassword:    "secret",
+		ICEUDPPortMin:   "50000",
+		ICEUDPPortMax:   "50100",
 	}
 	if err := valid.Validate(); err != nil {
 		t.Fatalf("valid config rejected: %v", err)
@@ -27,6 +29,8 @@ func TestWorkerConfigValidate(t *testing.T) {
 		{"missing control-plane URL", func(c *WorkerConfig) { c.ControlPlaneURL = "" }},
 		{"partial registry credentials", func(c *WorkerConfig) { c.RegistryUser = "user" }},
 		{"missing TURN password", func(c *WorkerConfig) { c.TURNPassword = "" }},
+		{"partial ICE UDP range", func(c *WorkerConfig) { c.ICEUDPPortMax = "" }},
+		{"reversed ICE UDP range", func(c *WorkerConfig) { c.ICEUDPPortMin = "50101" }},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -50,6 +54,8 @@ func TestWorkerConfigRender(t *testing.T) {
 		TURNServer:      "turn:turn.example.com:3478",
 		TURNUsername:    "turn-user",
 		TURNPassword:    "turn-secret",
+		ICEUDPPortMin:   "50000",
+		ICEUDPPortMax:   "50100",
 	}
 
 	rendered := cfg.Render("sfu-123", "room-456")
@@ -61,6 +67,9 @@ func TestWorkerConfigRender(t *testing.T) {
 		"export SFU_REGISTRY_PASSWORD='pa'\"'\"'ss; echo unsafe'",
 		"docker run",
 		"-e TURN_PASSWORD=\"${TURN_PASSWORD:-}\"",
+		"export ICE_UDP_PORT_MIN='50000'",
+		"export ICE_UDP_PORT_MAX='50100'",
+		"-e ICE_UDP_PORT_MIN=\"${ICE_UDP_PORT_MIN:-}\"",
 		"conf?format=json",
 		".public_ips_v4[0].address // .public_ip.address // empty",
 	}

--- a/sfuServer/deploy/scaleway-worker-bootstrap.sh
+++ b/sfuServer/deploy/scaleway-worker-bootstrap.sh
@@ -103,5 +103,7 @@ docker run \
   -e TURN_PASSWORD="${TURN_PASSWORD:-}" \
   -e ICE_RELAY_ONLY="$ICE_RELAY_ONLY" \
   -e ENABLE_ICE_TCP="${ENABLE_ICE_TCP:-false}" \
+  -e ICE_UDP_PORT_MIN="${ICE_UDP_PORT_MIN:-}" \
+  -e ICE_UDP_PORT_MAX="${ICE_UDP_PORT_MAX:-}" \
   -e SERVER_PORT="$SFU_PORT" \
   "$IMAGE"

--- a/sfuServer/handlers.go
+++ b/sfuServer/handlers.go
@@ -7,8 +7,10 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/pion/webrtc/v4"
 )
@@ -124,7 +126,67 @@ func getWebRTCConfiguration() webrtc.Configuration {
 func setCORSHeaders(w http.ResponseWriter, methods string) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", methods)
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Expose-Headers", "Location, Link")
+}
+
+// addWHIPICEServerLinkHeaders advertises the TURN servers to WHIP clients.
+// OBS deliberately gathers its local candidates only after the WHIP response
+// and obtains its ICE server configuration from these Link headers.
+func addWHIPICEServerLinkHeaders(w http.ResponseWriter) {
+	turnServer := os.Getenv("TURN_SERVER")
+	turnUsername := os.Getenv("TURN_USERNAME")
+	turnPassword := os.Getenv("TURN_PASSWORD")
+	if turnServer == "" || turnUsername == "" || turnPassword == "" {
+		return
+	}
+
+	// Header values must never contain raw newlines. Quotes and backslashes in
+	// credentials are escaped as HTTP quoted-string characters.
+	if strings.ContainsAny(turnUsername, "\r\n") || strings.ContainsAny(turnPassword, "\r\n") {
+		log.Printf("[WHIP] TURN credentials contain invalid header characters; ICE servers not advertised")
+		return
+	}
+	escapeQuotedString := func(value string) string {
+		return strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(value)
+	}
+
+	for _, turnURL := range splitAndTrim(turnServer, ",") {
+		if !strings.HasPrefix(turnURL, "turn:") || strings.ContainsAny(turnURL, "\r\n<>") {
+			log.Printf("[WHIP] Skipping invalid TURN URL in Link header")
+			continue
+		}
+		w.Header().Add("Link", fmt.Sprintf(
+			`<%s>; rel="ice-server"; username="%s"; credential="%s"; credential-type="password"`,
+			turnURL,
+			escapeQuotedString(turnUsername),
+			escapeQuotedString(turnPassword),
+		))
+	}
+}
+
+func whipResourceLocation(roomID, key string) string {
+	return fmt.Sprintf("/whip/resource/%s/%s", url.PathEscape(roomID), url.PathEscape(key))
+}
+
+func parseWHIPResourcePath(requestPath string) (roomID, key string, ok bool) {
+	const prefix = "/whip/resource/"
+	if !strings.HasPrefix(requestPath, prefix) {
+		return "", "", false
+	}
+	parts := strings.SplitN(strings.TrimPrefix(requestPath, prefix), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	roomID, err := url.PathUnescape(parts[0])
+	if err != nil {
+		return "", "", false
+	}
+	key, err = url.PathUnescape(parts[1])
+	if err != nil {
+		return "", "", false
+	}
+	return roomID, key, true
 }
 
 // handleHealthCheck handles the health check endpoint
@@ -508,15 +570,14 @@ func handleWHIP(w http.ResponseWriter, r *http.Request) {
 		}
 	})
 
-	// Track cleanup state to prevent multiple cleanup calls
-	removed := false
+	// Track cleanup state to prevent concurrent ICE/PeerConnection callbacks
+	// from initiating the same room cleanup more than once.
+	var cleanupOnce sync.Once
 	cleanupHost := func(reason string) {
-		if removed {
-			return
-		}
-		removed = true
-		log.Printf("[WHIP][ROOM-%s] Host cleanup due to %s", roomID, reason)
-		room.CleanupHost()
+		cleanupOnce.Do(func() {
+			log.Printf("[WHIP][ROOM-%s] Host cleanup due to %s", roomID, reason)
+			room.CleanupHost()
+		})
 	}
 
 	peerConnection.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
@@ -575,8 +636,10 @@ func handleWHIP(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[WHIP][ROOM-%s] ICE gathering complete", roomID)
 
-	// Required by WHIP spec
-	w.Header().Set("Location", fmt.Sprintf("/whip/%s", roomID))
+	// Required by WHIP: Location identifies the session resource that OBS will
+	// DELETE when publishing stops. Link supplies the ICE servers OBS must use.
+	w.Header().Set("Location", whipResourceLocation(roomID, key))
+	addWHIPICEServerLinkHeaders(w)
 	w.Header().Set("Content-Type", "application/sdp")
 	w.WriteHeader(http.StatusCreated)
 
@@ -585,6 +648,40 @@ func handleWHIP(w http.ResponseWriter, r *http.Request) {
 
 	_, _ = w.Write([]byte(answerSDP))
 	log.Printf("[WHIP][ROOM-%s] Response sent successfully", roomID)
+}
+
+// handleWHIPResource terminates the publishing session represented by the
+// Location returned from handleWHIP. The room key is kept in the opaque path
+// so native WHIP clients such as OBS can authenticate their DELETE request.
+func handleWHIPResource(w http.ResponseWriter, r *http.Request) {
+	setCORSHeaders(w, "DELETE, OPTIONS")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Only DELETE is supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	roomID, key, ok := parseWHIPResourcePath(r.URL.Path)
+	if !ok {
+		http.Error(w, "Invalid WHIP resource", http.StatusBadRequest)
+		return
+	}
+	room, err := sfuServer.GetRoom(roomID)
+	if err != nil {
+		http.Error(w, "Room not found", http.StatusNotFound)
+		return
+	}
+	if room.Key != key {
+		http.Error(w, "Invalid key", http.StatusUnauthorized)
+		return
+	}
+
+	room.CleanupHost()
+	w.WriteHeader(http.StatusOK)
+	log.Printf("[WHIP][ROOM-%s] Publishing session deleted", roomID)
 }
 
 // handleCascadeSubscribe handles edge SFU subscribing to origin SFU

--- a/sfuServer/handlers.go
+++ b/sfuServer/handlers.go
@@ -17,10 +17,18 @@ import (
 var webrtcAPI *webrtc.API
 
 func init() {
+	api, err := newWebRTCAPI(os.Getenv("PUBLIC_IP"), os.Getenv("ICE_RELAY_ONLY") == "true")
+	if err != nil {
+		log.Fatalf("[ICE] Failed to initialize WebRTC API: %v", err)
+	}
+	webrtcAPI = api
+}
+
+func newWebRTCAPI(publicIP string, relayOnly bool) (*webrtc.API, error) {
 	// Create a MediaEngine with default codecs
 	mediaEngine := &webrtc.MediaEngine{}
 	if err := mediaEngine.RegisterDefaultCodecs(); err != nil {
-		log.Fatalf("[ICE] Failed to register default codecs: %v", err)
+		return nil, fmt.Errorf("register default codecs: %w", err)
 	}
 
 	// Create a SettingEngine for advanced WebRTC configuration
@@ -28,10 +36,11 @@ func init() {
 
 	// If a public IP is specified, use NAT1To1 mapping
 	// This is useful when running behind a NAT (like in containers)
-	publicIP := os.Getenv("PUBLIC_IP")
-	if publicIP != "" {
+	if publicIP != "" && !relayOnly {
 		log.Printf("[ICE] Using NAT1To1 IP mapping: %s", publicIP)
 		settingEngine.SetNAT1To1IPs([]string{publicIP}, webrtc.ICECandidateTypeHost)
+	} else if publicIP != "" {
+		log.Printf("[ICE] Skipping NAT1To1 IP mapping in relay-only mode")
 	}
 
 	// Enable ICE-TCP candidates for environments that don't support UDP
@@ -51,10 +60,10 @@ func init() {
 	}
 
 	// Create the WebRTC API with MediaEngine and SettingEngine
-	webrtcAPI = webrtc.NewAPI(
+	return webrtc.NewAPI(
 		webrtc.WithMediaEngine(mediaEngine),
 		webrtc.WithSettingEngine(settingEngine),
-	)
+	), nil
 }
 
 // getWebRTCConfiguration returns the WebRTC configuration with ICE servers

--- a/sfuServer/handlers.go
+++ b/sfuServer/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -35,6 +36,22 @@ func newWebRTCAPI(publicIP string, relayOnly bool) (*webrtc.API, error) {
 
 	// Create a SettingEngine for advanced WebRTC configuration
 	settingEngine := webrtc.SettingEngine{}
+	udpPortMin := strings.TrimSpace(os.Getenv("ICE_UDP_PORT_MIN"))
+	udpPortMax := strings.TrimSpace(os.Getenv("ICE_UDP_PORT_MAX"))
+	if udpPortMin != "" || udpPortMax != "" {
+		if udpPortMin == "" || udpPortMax == "" {
+			return nil, fmt.Errorf("ICE_UDP_PORT_MIN and ICE_UDP_PORT_MAX must be set together")
+		}
+		minPort, minErr := strconv.ParseUint(udpPortMin, 10, 16)
+		maxPort, maxErr := strconv.ParseUint(udpPortMax, 10, 16)
+		if minErr != nil || maxErr != nil || minPort == 0 || maxPort == 0 {
+			return nil, fmt.Errorf("invalid ICE UDP port range %q-%q", udpPortMin, udpPortMax)
+		}
+		if err := settingEngine.SetEphemeralUDPPortRange(uint16(minPort), uint16(maxPort)); err != nil {
+			return nil, fmt.Errorf("set ICE UDP port range %d-%d: %w", minPort, maxPort, err)
+		}
+		log.Printf("[ICE] Using bounded UDP port range: %d-%d", minPort, maxPort)
+	}
 
 	// If a public IP is specified, use NAT1To1 mapping
 	// This is useful when running behind a NAT (like in containers)

--- a/sfuServer/handlers_ice_test.go
+++ b/sfuServer/handlers_ice_test.go
@@ -51,6 +51,8 @@ func TestWHIPResourceLocationRoundTrip(t *testing.T) {
 }
 
 func TestRelayOnlyAllowsPublicIPWithoutHostCandidateRewrite(t *testing.T) {
+	t.Setenv("ICE_UDP_PORT_MIN", "")
+	t.Setenv("ICE_UDP_PORT_MAX", "")
 	api, err := newWebRTCAPI("203.0.113.10", true)
 	if err != nil {
 		t.Fatalf("create WebRTC API: %v", err)
@@ -82,5 +84,14 @@ func TestRelayOnlyAllowsPublicIPWithoutHostCandidateRewrite(t *testing.T) {
 
 	if err := answerer.SetRemoteDescription(offer); err != nil {
 		t.Fatalf("relay-only answerer rejected a valid offer with PUBLIC_IP set: %v", err)
+	}
+}
+
+func TestWebRTCAPIRejectsInvalidUDPPortRange(t *testing.T) {
+	t.Setenv("ICE_UDP_PORT_MIN", "50100")
+	t.Setenv("ICE_UDP_PORT_MAX", "50000")
+
+	if _, err := newWebRTCAPI("203.0.113.10", false); err == nil {
+		t.Fatal("expected an invalid ICE UDP port range to be rejected")
 	}
 }

--- a/sfuServer/handlers_ice_test.go
+++ b/sfuServer/handlers_ice_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+)
+
+func TestRelayOnlyAllowsPublicIPWithoutHostCandidateRewrite(t *testing.T) {
+	api, err := newWebRTCAPI("203.0.113.10", true)
+	if err != nil {
+		t.Fatalf("create WebRTC API: %v", err)
+	}
+
+	answerer, err := api.NewPeerConnection(webrtc.Configuration{
+		ICETransportPolicy: webrtc.ICETransportPolicyRelay,
+	})
+	if err != nil {
+		t.Fatalf("create answerer: %v", err)
+	}
+	defer answerer.Close()
+
+	offerer, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatalf("create offerer: %v", err)
+	}
+	defer offerer.Close()
+	if _, err := offerer.AddTransceiverFromKind(
+		webrtc.RTPCodecTypeVideo,
+		webrtc.RTPTransceiverInit{Direction: webrtc.RTPTransceiverDirectionSendonly},
+	); err != nil {
+		t.Fatalf("add video transceiver: %v", err)
+	}
+	offer, err := offerer.CreateOffer(nil)
+	if err != nil {
+		t.Fatalf("create offer: %v", err)
+	}
+
+	if err := answerer.SetRemoteDescription(offer); err != nil {
+		t.Fatalf("relay-only answerer rejected a valid offer with PUBLIC_IP set: %v", err)
+	}
+}

--- a/sfuServer/handlers_ice_test.go
+++ b/sfuServer/handlers_ice_test.go
@@ -1,10 +1,54 @@
 package main
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/pion/webrtc/v4"
 )
+
+func TestAddWHIPICEServerLinkHeaders(t *testing.T) {
+	t.Setenv("TURN_SERVER", "turn:turn.example.test:3478?transport=udp,turn:turn.example.test:3478?transport=tcp")
+	t.Setenv("TURN_USERNAME", "obs-user")
+	t.Setenv("TURN_PASSWORD", "obs-password")
+
+	recorder := httptest.NewRecorder()
+	addWHIPICEServerLinkHeaders(recorder)
+
+	got := recorder.Header().Values("Link")
+	want := []string{
+		`<turn:turn.example.test:3478?transport=udp>; rel="ice-server"; username="obs-user"; credential="obs-password"; credential-type="password"`,
+		`<turn:turn.example.test:3478?transport=tcp>; rel="ice-server"; username="obs-user"; credential="obs-password"; credential-type="password"`,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Link headers = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Link header %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestAddWHIPICEServerLinkHeadersRequiresCompleteCredentials(t *testing.T) {
+	t.Setenv("TURN_SERVER", "turn:turn.example.test:3478")
+	t.Setenv("TURN_USERNAME", "obs-user")
+	t.Setenv("TURN_PASSWORD", "")
+
+	recorder := httptest.NewRecorder()
+	addWHIPICEServerLinkHeaders(recorder)
+	if got := recorder.Header().Values("Link"); len(got) != 0 {
+		t.Fatalf("Link headers = %q, want none", got)
+	}
+}
+
+func TestWHIPResourceLocationRoundTrip(t *testing.T) {
+	location := whipResourceLocation("room/with spaces", "secret-key")
+	roomID, key, ok := parseWHIPResourcePath(location)
+	if !ok || roomID != "room/with spaces" || key != "secret-key" {
+		t.Fatalf("parseWHIPResourcePath(%q) = room=%q key=%q ok=%v", location, roomID, key, ok)
+	}
+}
 
 func TestRelayOnlyAllowsPublicIPWithoutHostCandidateRewrite(t *testing.T) {
 	api, err := newWebRTCAPI("203.0.113.10", true)

--- a/sfuServer/internal/autoscaler/provisioner.go
+++ b/sfuServer/internal/autoscaler/provisioner.go
@@ -220,7 +220,7 @@ func (p *Provisioner) ReleaseCapacity(ctx context.Context, roomID string) error 
 			return fmt.Errorf("autoscaler: drain worker %s: %w", rec.SFUID, err)
 		}
 	}
-	if room, exists := p.store.Get(roomID); exists && room.State != models.RoomDraining {
+	if room, exists := p.store.Get(roomID); exists && room.State != models.RoomDraining && room.State != models.RoomTerminated {
 		if _, err := p.store.Upsert(roomID, models.RoomDraining, "idle timeout"); err != nil {
 			return fmt.Errorf("autoscaler: drain room %s: %w", roomID, err)
 		}
@@ -243,8 +243,10 @@ func (p *Provisioner) destroyDrainingLocked(ctx context.Context, rec models.Work
 		return fmt.Errorf("autoscaler: mark worker %s terminated: %w", rec.SFUID, err)
 	}
 	if rec.RoomID != "" {
-		if _, err := p.store.Upsert(rec.RoomID, models.RoomTerminated, "idle timeout"); err != nil {
-			return fmt.Errorf("autoscaler: mark room %s terminated: %w", rec.RoomID, err)
+		if room, exists := p.store.Get(rec.RoomID); !exists || room.State != models.RoomTerminated {
+			if _, err := p.store.Upsert(rec.RoomID, models.RoomTerminated, "idle timeout"); err != nil {
+				return fmt.Errorf("autoscaler: mark room %s terminated: %w", rec.RoomID, err)
+			}
 		}
 	}
 	return nil

--- a/sfuServer/internal/autoscaler/provisioner_test.go
+++ b/sfuServer/internal/autoscaler/provisioner_test.go
@@ -216,6 +216,46 @@ func TestReleaseCapacityDrainsAndDestroysWorker(t *testing.T) {
 	}
 }
 
+func TestReleaseCapacityDestroysWorkerWhenOwnerRoomAlreadyTerminated(t *testing.T) {
+	ctx := context.Background()
+	fake := provider.NewFake()
+	p, store := newTestProvisioner(t, fake, 1)
+
+	rec, err := p.EnsureCapacity(ctx, "room-owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, state := range []models.WorkerState{models.WorkerRegistered, models.WorkerReady} {
+		rec.State = state
+		if _, err := store.UpsertWorker(rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.Upsert("room-owner", models.RoomReady, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Upsert("room-owner", models.RoomDraining, "idle timeout"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Upsert("room-owner", models.RoomTerminated, "idle timeout"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Drain(rec.SFUID); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.ReleaseCapacity(ctx, "room-owner"); err != nil {
+		t.Fatal(err)
+	}
+	if fake.Count() != 0 {
+		t.Fatalf("worker Instance still exists: count=%d", fake.Count())
+	}
+	worker, _ := store.GetWorker(rec.SFUID)
+	if worker.State != models.WorkerTerminated {
+		t.Fatalf("worker state = %s, want terminated", worker.State)
+	}
+}
+
 func TestReleaseCapacityRetriesTransientDeleteFailure(t *testing.T) {
 	ctx := context.Background()
 	fake := provider.NewFake()

--- a/sfuServer/main.go
+++ b/sfuServer/main.go
@@ -62,6 +62,7 @@ func newServerMux() *http.ServeMux {
 	mux.HandleFunc("/room/viewers", handleRoomViewerCount)
 	mux.HandleFunc("/stream-status", handleStreamStatus)
 	mux.HandleFunc("/whip", handleWHIP)
+	mux.HandleFunc("/whip/resource/", handleWHIPResource)
 	mux.HandleFunc("/viewer", handleViewer)
 	mux.HandleFunc("/recorder", handleRecorder)
 	mux.HandleFunc("/promote", handlePromoteViewer)

--- a/sfuServer/main_test.go
+++ b/sfuServer/main_test.go
@@ -32,3 +32,33 @@ func TestServerMuxRegistersSyncCreateRoom(t *testing.T) {
 		t.Fatalf("synchronized room key = %q, want %q", room.Key, "room-key")
 	}
 }
+
+func TestServerMuxDeletesAuthenticatedWHIPResource(t *testing.T) {
+	t.Setenv("CONTROL_PLANE_URL", "")
+	sfuServer = NewSFUServer()
+	if err := sfuServer.CreateRoomWithKey("room-obs", "room-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	invalid := httptest.NewRequest(http.MethodDelete, "/whip/resource/room-obs/wrong-key", nil)
+	invalidRecorder := httptest.NewRecorder()
+	newServerMux().ServeHTTP(invalidRecorder, invalid)
+	if invalidRecorder.Code != http.StatusUnauthorized {
+		t.Fatalf("DELETE with invalid key = %d, want %d", invalidRecorder.Code, http.StatusUnauthorized)
+	}
+
+	request := httptest.NewRequest(http.MethodDelete, "/whip/resource/room-obs/room-key", nil)
+	recorder := httptest.NewRecorder()
+	newServerMux().ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("DELETE WHIP resource = %d (%s), want %d", recorder.Code, recorder.Body.String(), http.StatusOK)
+	}
+
+	room, err := sfuServer.GetRoom("room-obs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !room.CancelScheduledCleanup() {
+		t.Fatal("WHIP resource deletion did not schedule host cleanup")
+	}
+}

--- a/sfuServer/pkg/controlplane/controlplane.go
+++ b/sfuServer/pkg/controlplane/controlplane.go
@@ -111,6 +111,7 @@ type ControlPlane struct {
 // cold-start path testable).
 type capacityEnsurer interface {
 	EnsureCapacity(ctx context.Context, roomID string) (models.WorkerRecord, error)
+	Drain(sfuID string) error
 	ReleaseCapacity(ctx context.Context, roomID string) error
 }
 
@@ -438,6 +439,7 @@ func (cp *ControlPlane) scheduleTopologyCleanup(roomID string) {
 	if !exists {
 		return
 	}
+	ingestionSFUID := topology.IngestionSFUID
 
 	// Collect relay SFUs to notify
 	relaysToNotify := make([]string, 0)
@@ -458,16 +460,74 @@ func (cp *ControlPlane) scheduleTopologyCleanup(roomID string) {
 
 	// Notify ALL SFUs to delete the room so it can be re-created with a new key later
 	go cp.syncRoomDeletionToAllSFUs(roomID)
+	cp.markRoomTerminated(roomID)
 
 	// The topology grace period doubles as the first-stage idle timeout. Once it
-	// expires, release only capacity tracked by the on-demand provisioner; rooms
-	// hosted on static SFUs are a no-op.
+	// expires, release only capacity tracked by the on-demand provisioner. A
+	// ready worker may host multiple rooms, so removing one room must not destroy
+	// capacity that another topology still references.
 	if cp.provisioner != nil {
+		if ingestionSFUID != "" {
+			for otherRoomID, otherTopology := range cp.rooms {
+				if _, stillReferenced := otherTopology.Nodes[ingestionSFUID]; stillReferenced {
+					log.Printf("[CP-CLEANUP] Retaining SFU %s after room %s cleanup; still serving room %s", ingestionSFUID, roomID, otherRoomID)
+					return
+				}
+			}
+
+			// Resolve the provisioner's owning room before draining. Reused rooms
+			// are not the worker record's original RoomID.
+			releaseRoomID := roomID
+			if cp.roomState != nil {
+				if worker, tracked := cp.roomState.GetWorker(ingestionSFUID); tracked {
+					releaseRoomID = worker.RoomID
+					// Drain synchronously while cp.mu is held so selectIngestionSFU
+					// cannot assign a new room between the final reference check and
+					// asynchronous destruction.
+					if err := cp.provisioner.Drain(ingestionSFUID); err != nil {
+						log.Printf("[CP-CLEANUP] drain SFU %s after room %s: %v", ingestionSFUID, roomID, err)
+						return
+					}
+				}
+			}
+
+			go func() {
+				if err := cp.provisioner.ReleaseCapacity(context.Background(), releaseRoomID); err != nil {
+					log.Printf("[CP-CLEANUP] release capacity for worker %s (owner room %s): %v", ingestionSFUID, releaseRoomID, err)
+				}
+			}()
+			return
+		}
+
+		// Legacy/static test topologies may not carry an ingestion SFU. Preserve
+		// the room-keyed release path; untracked static capacity remains a no-op.
 		go func() {
 			if err := cp.provisioner.ReleaseCapacity(context.Background(), roomID); err != nil {
 				log.Printf("[CP-CLEANUP] release capacity for room %s: %v", roomID, err)
 			}
 		}()
+	}
+}
+
+// markRoomTerminated records topology removal independently from worker
+// destruction. This matters when a worker is shared: the cleaned room is
+// terminal even though the worker remains ready for another active room.
+func (cp *ControlPlane) markRoomTerminated(roomID string) {
+	if cp.roomState == nil {
+		return
+	}
+	room, exists := cp.roomState.Get(roomID)
+	if !exists || room.State == models.RoomTerminated {
+		return
+	}
+	if room.State == models.RoomReady {
+		if _, err := cp.roomState.Upsert(roomID, models.RoomDraining, "idle timeout"); err != nil {
+			log.Printf("[CP-CLEANUP] mark room %s draining: %v", roomID, err)
+			return
+		}
+	}
+	if _, err := cp.roomState.Upsert(roomID, models.RoomTerminated, "idle timeout"); err != nil {
+		log.Printf("[CP-CLEANUP] mark room %s terminated: %v", roomID, err)
 	}
 }
 

--- a/sfuServer/pkg/controlplane/controlplane.go
+++ b/sfuServer/pkg/controlplane/controlplane.go
@@ -1602,6 +1602,95 @@ func (cp *ControlPlane) HandleWHIP(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[CP-WHIP] WHIP request for room %s successfully proxied to SFU %s", roomID, ingestionSFUID)
 }
 
+func parseWHIPResourcePath(requestPath string) (roomID, key string, ok bool) {
+	const prefix = "/whip/resource/"
+	if !strings.HasPrefix(requestPath, prefix) {
+		return "", "", false
+	}
+	parts := strings.SplitN(strings.TrimPrefix(requestPath, prefix), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	roomID, err := url.PathUnescape(parts[0])
+	if err != nil {
+		return "", "", false
+	}
+	key, err = url.PathUnescape(parts[1])
+	if err != nil {
+		return "", "", false
+	}
+	return roomID, key, true
+}
+
+// HandleWHIPResource proxies termination of the resource returned in the
+// WHIP Location header to the worker that owns the room.
+func (cp *ControlPlane) HandleWHIPResource(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "Only DELETE is supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	roomID, key, ok := parseWHIPResourcePath(r.URL.Path)
+	if !ok {
+		http.Error(w, "Invalid WHIP resource", http.StatusBadRequest)
+		return
+	}
+
+	cp.mu.RLock()
+	topology, exists := cp.rooms[roomID]
+	invalidKey := exists && topology.Key != key
+	if !exists || invalidKey || topology.IngestionSFUID == "" {
+		cp.mu.RUnlock()
+		if invalidKey {
+			http.Error(w, "Invalid key", http.StatusUnauthorized)
+			return
+		}
+		http.Error(w, "WHIP resource not found", http.StatusNotFound)
+		return
+	}
+	ingestionSFUID := topology.IngestionSFUID
+	sfu, exists := cp.sfus[ingestionSFUID]
+	if !exists || !sfu.Active {
+		cp.mu.RUnlock()
+		http.Error(w, "Ingestion SFU is not available", http.StatusServiceUnavailable)
+		return
+	}
+	ingestionURL := sfu.URL
+	cp.mu.RUnlock()
+
+	targetURL, err := url.Parse(ingestionURL)
+	if err != nil {
+		log.Printf("[CP-WHIP] Failed to parse resource target URL for room %s: %v", roomID, err)
+		http.Error(w, "Invalid SFU URL", http.StatusInternalServerError)
+		return
+	}
+	targetURL.Path = r.URL.Path
+	targetURL.RawQuery = ""
+
+	proxy := httputil.NewSingleHostReverseProxy(targetURL)
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.Host = targetURL.Host
+		req.URL.Path = targetURL.Path
+		req.URL.RawQuery = ""
+	}
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		resp.Header.Del("Access-Control-Allow-Origin")
+		resp.Header.Del("Access-Control-Allow-Methods")
+		resp.Header.Del("Access-Control-Allow-Headers")
+		resp.Header.Del("Access-Control-Expose-Headers")
+		return nil
+	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+		log.Printf("[CP-WHIP] Resource delete proxy error to SFU %s: %v", ingestionSFUID, err)
+		http.Error(w, "Failed to delete WHIP resource", http.StatusBadGateway)
+	}
+
+	proxy.ServeHTTP(w, r)
+	log.Printf("[CP-WHIP] Resource for room %s deleted on SFU %s", roomID, ingestionSFUID)
+}
+
 // HandleViewer proxies viewer requests to the optimal SFU
 func (cp *ControlPlane) HandleViewer(w http.ResponseWriter, r *http.Request) {
 	// Extract room_id from query parameters

--- a/sfuServer/pkg/controlplane/controlplane.go
+++ b/sfuServer/pkg/controlplane/controlplane.go
@@ -1753,6 +1753,11 @@ func (cp *ControlPlane) HandleWHIPResource(w http.ResponseWriter, r *http.Reques
 
 // HandleViewer proxies viewer requests to the optimal SFU
 func (cp *ControlPlane) HandleViewer(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		http.Error(w, "Only GET and POST are supported", http.StatusMethodNotAllowed)
+		return
+	}
+
 	// Extract room_id from query parameters
 	roomID := r.URL.Query().Get("room_id")
 	if roomID == "" {
@@ -1970,8 +1975,46 @@ func (cp *ControlPlane) HandleViewer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return the SFU info to the viewer (NO PROXYING - direct connection)
-	log.Printf("[CP-VIEWER] Returning SFU %s for direct viewer connection in room %s", targetSFUID, roomID)
+	if r.Method == http.MethodPost {
+		target, err := url.Parse(targetURL)
+		if err != nil {
+			log.Printf("[CP-VIEWER] Failed to parse target URL %s: %v", targetURL, err)
+			http.Error(w, "Invalid SFU URL", http.StatusInternalServerError)
+			return
+		}
+		target.Path = "/viewer"
+		target.RawQuery = r.URL.RawQuery
+
+		log.Printf("[CP-VIEWER] Proxying viewer SDP for room %s to SFU %s", roomID, targetSFUID)
+		proxy := httputil.NewSingleHostReverseProxy(target)
+		originalDirector := proxy.Director
+		proxy.Director = func(req *http.Request) {
+			originalDirector(req)
+			req.Host = target.Host
+			req.URL.Path = "/viewer"
+			req.URL.RawQuery = r.URL.RawQuery
+		}
+		proxy.ModifyResponse = func(resp *http.Response) error {
+			// The public control-plane CORS middleware owns these headers. Keeping
+			// worker headers here can produce duplicate Access-Control values.
+			resp.Header.Del("Access-Control-Allow-Origin")
+			resp.Header.Del("Access-Control-Allow-Methods")
+			resp.Header.Del("Access-Control-Allow-Headers")
+			resp.Header.Del("Access-Control-Expose-Headers")
+			return nil
+		}
+		proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+			log.Printf("[CP-VIEWER] Proxy error to SFU %s: %v", targetSFUID, err)
+			http.Error(w, "Failed to proxy viewer negotiation to SFU", http.StatusBadGateway)
+		}
+		proxy.ServeHTTP(w, r)
+		return
+	}
+
+	// Keep GET discovery for backwards compatibility and non-browser clients.
+	// Browser viewers POST their SDP to this TLS endpoint so private worker URLs
+	// are never exposed as mixed-content fetch targets.
+	log.Printf("[CP-VIEWER] Returning SFU %s discovery information for room %s", targetSFUID, roomID)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/sfuServer/pkg/controlplane/controlplane_test.go
+++ b/sfuServer/pkg/controlplane/controlplane_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -504,6 +505,105 @@ func TestWHIPResponsePreservesICEAndResourceHeaders(t *testing.T) {
 	}
 	if got := recorder.Header().Get("Link"); got != link {
 		t.Fatalf("Link = %q, want %q", got, link)
+	}
+}
+
+func TestViewerPOSTIsProxiedThroughControlPlane(t *testing.T) {
+	const offer = "v=0\r\na=recvonly\r\n"
+	const answer = "v=0\r\na=sendonly\r\n"
+	workerCalled := make(chan struct{}, 1)
+	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("worker method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/viewer" || r.URL.Query().Get("room_id") != "room-1" {
+			t.Errorf("worker URL = %s, want /viewer?room_id=room-1", r.URL.String())
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != offer {
+			t.Errorf("worker body = %q, want %q", body, offer)
+		}
+		workerCalled <- struct{}{}
+		w.Header().Set("Content-Type", "application/sdp")
+		w.Header().Set("Access-Control-Allow-Origin", "http://private-worker")
+		_, _ = w.Write([]byte(answer))
+	}))
+	defer worker.Close()
+
+	cp := newTestCP(t)
+	cp.rooms["room-1"] = &models.RoomTopology{
+		RoomID:         "room-1",
+		IngestionSFUID: "sfu-1",
+		Nodes: map[string]*models.TopologyNode{
+			"sfu-1": {SFUID: "sfu-1", RoomID: "room-1", Role: "ingestion"},
+		},
+	}
+	cp.sfus["sfu-1"] = &SFUInfo{
+		ID:      "sfu-1",
+		URL:     worker.URL,
+		Active:  true,
+		Metrics: &models.SFUMetrics{SFUID: "sfu-1", CPU: 0.1, Memory: 0.1},
+	}
+	if _, err := cp.roomState.Upsert("room-1", models.RoomReady, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	cp.HandleViewer(recorder, httptest.NewRequest(
+		http.MethodPost,
+		"/viewer?room_id=room-1",
+		strings.NewReader(offer),
+	))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("POST viewer = %d (%s), want %d", recorder.Code, recorder.Body.String(), http.StatusOK)
+	}
+	if recorder.Body.String() != answer {
+		t.Fatalf("viewer answer = %q, want %q", recorder.Body.String(), answer)
+	}
+	if got := recorder.Header().Get("Content-Type"); got != "application/sdp" {
+		t.Fatalf("Content-Type = %q, want application/sdp", got)
+	}
+	if got := recorder.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("worker CORS header leaked through proxy: %q", got)
+	}
+	select {
+	case <-workerCalled:
+	case <-time.After(time.Second):
+		t.Fatal("viewer POST was not proxied to the worker")
+	}
+}
+
+func TestViewerGETDiscoveryRemainsAvailable(t *testing.T) {
+	cp := newTestCP(t)
+	cp.rooms["room-1"] = &models.RoomTopology{
+		RoomID:         "room-1",
+		IngestionSFUID: "sfu-1",
+		Nodes:          make(map[string]*models.TopologyNode),
+	}
+	cp.sfus["sfu-1"] = &SFUInfo{
+		ID:      "sfu-1",
+		URL:     "http://worker.internal:8090",
+		Active:  true,
+		Metrics: &models.SFUMetrics{SFUID: "sfu-1", CPU: 0.1, Memory: 0.1},
+	}
+	if _, err := cp.roomState.Upsert("room-1", models.RoomReady, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	cp.HandleViewer(recorder, httptest.NewRequest(http.MethodGet, "/viewer?room_id=room-1", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET viewer = %d (%s), want %d", recorder.Code, recorder.Body.String(), http.StatusOK)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["sfu_url"] != "http://worker.internal:8090" {
+		t.Fatalf("unexpected discovery response: %+v", body)
 	}
 }
 

--- a/sfuServer/pkg/controlplane/controlplane_test.go
+++ b/sfuServer/pkg/controlplane/controlplane_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -334,6 +335,102 @@ func TestMediaFlowsGatedOnReadiness(t *testing.T) {
 	cp.HandleWHIP(rec, httptest.NewRequest(http.MethodPost, "/whip?room_id=room-1&key="+key, nil))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("WHIP while failed = %d, want 409", rec.Code)
+	}
+}
+
+func TestWHIPResourceDeleteIsAuthenticatedAndProxied(t *testing.T) {
+	workerCalled := make(chan struct{}, 1)
+	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("worker method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/whip/resource/room-1/room-key" {
+			t.Errorf("worker path = %s", r.URL.Path)
+		}
+		workerCalled <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer worker.Close()
+
+	cp := newTestCP(t)
+	cp.rooms["room-1"] = &models.RoomTopology{
+		RoomID:         "room-1",
+		Key:            "room-key",
+		IngestionSFUID: "sfu-1",
+		Nodes:          make(map[string]*models.TopologyNode),
+	}
+	cp.sfus["sfu-1"] = &SFUInfo{ID: "sfu-1", URL: worker.URL, Active: true}
+
+	invalid := httptest.NewRecorder()
+	cp.HandleWHIPResource(invalid, httptest.NewRequest(
+		http.MethodDelete,
+		"/whip/resource/room-1/wrong-key",
+		nil,
+	))
+	if invalid.Code != http.StatusUnauthorized {
+		t.Fatalf("DELETE with invalid key = %d, want %d", invalid.Code, http.StatusUnauthorized)
+	}
+
+	recorder := httptest.NewRecorder()
+	cp.HandleWHIPResource(recorder, httptest.NewRequest(
+		http.MethodDelete,
+		"/whip/resource/room-1/room-key",
+		nil,
+	))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("DELETE WHIP resource = %d (%s), want %d", recorder.Code, recorder.Body.String(), http.StatusOK)
+	}
+	select {
+	case <-workerCalled:
+	case <-time.After(time.Second):
+		t.Fatal("DELETE was not proxied to the ingestion SFU")
+	}
+}
+
+func TestWHIPResponsePreservesICEAndResourceHeaders(t *testing.T) {
+	const link = `<turn:turn.example.test:3478?transport=tcp>; rel="ice-server"; username="user"; credential="password"`
+	worker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/room/sync-create":
+			w.WriteHeader(http.StatusCreated)
+		case "/whip":
+			w.Header().Set("Content-Type", "application/sdp")
+			w.Header().Set("Location", "/whip/resource/room-1/room-key")
+			w.Header().Add("Link", link)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte("v=0\r\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer worker.Close()
+
+	cp := newTestCP(t)
+	cp.rooms["room-1"] = &models.RoomTopology{
+		RoomID:         "room-1",
+		Key:            "room-key",
+		IngestionSFUID: "sfu-1",
+		Nodes:          make(map[string]*models.TopologyNode),
+	}
+	cp.sfus["sfu-1"] = &SFUInfo{ID: "sfu-1", URL: worker.URL, Active: true}
+	if _, err := cp.roomState.Upsert("room-1", models.RoomReady, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	cp.HandleWHIP(recorder, httptest.NewRequest(
+		http.MethodPost,
+		"/whip?room_id=room-1&key=room-key",
+		strings.NewReader("v=0\r\n"),
+	))
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("POST WHIP = %d (%s), want %d", recorder.Code, recorder.Body.String(), http.StatusCreated)
+	}
+	if got := recorder.Header().Get("Location"); got != "/whip/resource/room-1/room-key" {
+		t.Fatalf("Location = %q", got)
+	}
+	if got := recorder.Header().Get("Link"); got != link {
+		t.Fatalf("Link = %q, want %q", got, link)
 	}
 }
 

--- a/sfuServer/pkg/controlplane/controlplane_test.go
+++ b/sfuServer/pkg/controlplane/controlplane_test.go
@@ -20,8 +20,16 @@ import (
 // stubEnsurer stands in for the autoscaler in control-plane tests.
 type stubEnsurer struct {
 	called   chan string
+	drained  chan string
 	released chan string
 	err      error
+}
+
+func (s *stubEnsurer) Drain(sfuID string) error {
+	if s.drained != nil {
+		s.drained <- sfuID
+	}
+	return s.err
 }
 
 func (s *stubEnsurer) ReleaseCapacity(_ context.Context, roomID string) error {
@@ -94,6 +102,71 @@ func TestTopologyCleanupReleasesOnDemandCapacity(t *testing.T) {
 	}
 	if _, exists := cp.rooms["room-idle"]; exists {
 		t.Fatal("room topology still exists after cleanup")
+	}
+}
+
+func TestTopologyCleanupRetainsSharedWorkerUntilLastRoomEnds(t *testing.T) {
+	cp := newTestCP(t)
+	drained := make(chan string, 1)
+	released := make(chan string, 1)
+	cp.SetProvisioner(&stubEnsurer{drained: drained, released: released})
+
+	worker := models.WorkerRecord{SFUID: "sfu-shared", RoomID: "room-a", State: models.WorkerProvisioning}
+	for _, state := range []models.WorkerState{models.WorkerProvisioning, models.WorkerRegistered, models.WorkerReady} {
+		worker.State = state
+		if _, err := cp.roomState.UpsertWorker(worker); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, roomID := range []string{"room-a", "room-b"} {
+		if _, err := cp.roomState.Upsert(roomID, models.RoomProvisioning, ""); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cp.roomState.Upsert(roomID, models.RoomReady, ""); err != nil {
+			t.Fatal(err)
+		}
+		cp.rooms[roomID] = &models.RoomTopology{
+			RoomID:         roomID,
+			IngestionSFUID: "sfu-shared",
+			Nodes: map[string]*models.TopologyNode{
+				"sfu-shared": {SFUID: "sfu-shared", RoomID: roomID, Role: "ingestion"},
+			},
+		}
+	}
+
+	cp.scheduleTopologyCleanup("room-a")
+
+	select {
+	case got := <-drained:
+		t.Fatalf("shared worker drained while room-b was active: %s", got)
+	case got := <-released:
+		t.Fatalf("shared worker released while room-b was active: %s", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if room, _ := cp.roomState.Get("room-a"); room.State != models.RoomTerminated {
+		t.Fatalf("room-a state = %s, want terminated", room.State)
+	}
+
+	cp.scheduleTopologyCleanup("room-b")
+
+	select {
+	case got := <-drained:
+		if got != "sfu-shared" {
+			t.Fatalf("drained worker = %s, want sfu-shared", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("last room cleanup did not drain shared worker")
+	}
+	select {
+	case got := <-released:
+		if got != "room-a" {
+			t.Fatalf("released owner room = %s, want room-a", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("last room cleanup did not release shared worker")
+	}
+	if room, _ := cp.roomState.Get("room-b"); room.State != models.RoomTerminated {
+		t.Fatalf("room-b state = %s, want terminated", room.State)
 	}
 }
 


### PR DESCRIPTION
## Contexte

Les tests staging ont révélé trois incompatibilités dans le parcours OBS :

1. le endpoint WHIP n annonçait pas TURN à OBS dans les en-têtes `Link` ;
2. la ressource retournée par `Location` n acceptait pas le `DELETE` envoyé par OBS ;
3. même après ces corrections, OBS 31.0.1 restait en ICE `Connecting` avec un SFU strictement relay-only.

Le troisième point a été reproduit avec la bibliothèque exacte d OBS Flatpak (`libdatachannel 0.21`) : la même offre candidate-free se connecte immédiatement dès que le SFU expose aussi un candidat direct.

## Changements

- annonce TURN UDP et TCP dans les en-têtes WHIP `Link` ;
- expose une ressource WHIP authentifiée via `Location`, son handler `DELETE` et le proxy control-plane correspondant ;
- expose `Location`/`Link` via CORS et sérialise le nettoyage concurrent ;
- conserve la réécriture NAT uniquement lorsque les candidats host sont permis ;
- ajoute `ICE_UDP_PORT_MIN`/`ICE_UDP_PORT_MAX`, avec validation stricte ;
- propage la plage UDP bornée aux workers Scaleway éphémères ;
- ajoute les tests de régression worker, bootstrap et control-plane.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- reproduction avec libdatachannel 0.21 + TURN : échec en relay-only, connexion immédiate en direct borné `50000-50100`
- validation staging après déploiement de `sha-1d094be697cc` : cold start, WHIP 201, ICE connected en environ 220 ms et DELETE réussi

Le merge de cette PR reste volontairement bloqué jusqu à un test OBS réel réussi.