### PR TITLE
Fix authenticated search crashes and sharing metadata

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/logo_OCHOCAST.png" />
@@ -10,10 +10,30 @@
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#0d6f50" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="OchoCast, la plateforme vidéo pour suivre des lives, retrouver les replays et partager les connaissances."
+    />
+    <meta property="og:title" content="OchoCast" />
+    <meta
+      property="og:description"
+      content="Suivez les lives, retrouvez les replays et partagez les connaissances."
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:image"
+      content="https://demo.ochocast.fr/logo_OCHOCAST.png"
+    />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="OchoCast" />
+    <meta
+      name="twitter:description"
+      content="Suivez les lives, retrouvez les replays et partagez les connaissances."
+    />
+    <meta
+      name="twitter:image"
+      content="https://demo.ochocast.fr/logo_OCHOCAST.png"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo_OCHOCAST.png" />
     <!--

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,7 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "OchoCast",
+  "name": "OchoCast — la plateforme vidéo",
+  "description": "Suivez les lives, retrouvez les replays et partagez les connaissances.",
   "icons": [
     {
       "src": "favicon.ico",
@@ -10,6 +11,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
+  "theme_color": "#0d6f50",
   "background_color": "#ffffff"
 }

--- a/frontend/src/components/ReworkComponents/navigation/GlobalSearchBar/GlobalSearchBar.test.tsx
+++ b/frontend/src/components/ReworkComponents/navigation/GlobalSearchBar/GlobalSearchBar.test.tsx
@@ -81,8 +81,8 @@ describe('GlobalSearchBar', () => {
 
     await waitFor(() => {
       expect(mockedFindTags).toHaveBeenCalledWith('test');
-      expect(mockedFindUsers).toHaveBeenCalledWith('test');
     });
+    expect(mockedFindUsers).toHaveBeenCalledWith('test');
     expect(input).toHaveValue('test');
   });
 });

--- a/frontend/src/components/ReworkComponents/navigation/GlobalSearchBar/GlobalSearchBar.test.tsx
+++ b/frontend/src/components/ReworkComponents/navigation/GlobalSearchBar/GlobalSearchBar.test.tsx
@@ -1,0 +1,88 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { findTags, findUsers } from '../../../../utils/api';
+import GlobalSearchBar from './GlobalSearchBar';
+
+jest.mock('../../../../utils/api', () => ({
+  findTags: jest.fn(),
+  findUsers: jest.fn(),
+}));
+
+jest.mock('../../BrandingImage/BrandingImage', () => ({
+  __esModule: true,
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockedFindTags = findTags as jest.Mock;
+const mockedFindUsers = findUsers as jest.Mock;
+
+describe('GlobalSearchBar', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('debounces the search while the user is typing', async () => {
+    mockedFindTags.mockResolvedValue({ ok: true, status: 200, data: [] });
+    mockedFindUsers.mockResolvedValue({ ok: true, status: 200, data: [] });
+    const onSearch = jest.fn();
+
+    render(<GlobalSearchBar onSearch={onSearch} placeholder="Rechercher" />);
+
+    const input = screen.getByPlaceholderText('Rechercher');
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.change(input, { target: { value: 'ab' } });
+    fireEvent.change(input, { target: { value: 'abc' } });
+
+    expect(onSearch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+    expect(onSearch).toHaveBeenCalledWith('abc');
+  });
+
+  it('keeps rendering when suggestion endpoints return an HTTP error', async () => {
+    mockedFindTags.mockResolvedValue({
+      ok: false,
+      status: 401,
+      data: { message: 'Unauthorized' },
+    });
+    mockedFindUsers.mockResolvedValue({
+      ok: false,
+      status: 401,
+      data: { message: 'Unauthorized' },
+    });
+
+    render(<GlobalSearchBar onSearch={jest.fn()} placeholder="Rechercher" />);
+
+    const input = screen.getByPlaceholderText('Rechercher');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await waitFor(() => {
+      expect(mockedFindTags).toHaveBeenCalledWith('test');
+      expect(mockedFindUsers).toHaveBeenCalledWith('test');
+    });
+    expect(input).toHaveValue('test');
+  });
+});

--- a/frontend/src/components/ReworkComponents/navigation/GlobalSearchBar/GlobalSearchBar.tsx
+++ b/frontend/src/components/ReworkComponents/navigation/GlobalSearchBar/GlobalSearchBar.tsx
@@ -43,6 +43,8 @@ const GlobalSearchBar = ({
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const suggestionRequestRef = useRef(0);
 
   useEffect(() => {
     if (initialValue !== undefined) {
@@ -66,7 +68,17 @@ const GlobalSearchBar = ({
     };
   }, []);
 
-  const findSuggestions = async (queryEntered: string) => {
+  useEffect(
+    () => () => {
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+      suggestionRequestRef.current += 1;
+    },
+    [],
+  );
+
+  const findSuggestions = async (queryEntered: string, requestId: number) => {
     if (!hasSuggestion) return;
 
     try {
@@ -82,10 +94,26 @@ const GlobalSearchBar = ({
         findUsers(queryEntered),
       ]);
 
-      setTagSuggestions(tagResponse.data || []);
-      setUserSuggestions(userResponse.data || []);
+      if (requestId !== suggestionRequestRef.current) return;
+
+      if (
+        !tagResponse.ok ||
+        !userResponse.ok ||
+        !Array.isArray(tagResponse.data) ||
+        !Array.isArray(userResponse.data)
+      ) {
+        throw new Error(
+          `Suggestion request failed (${tagResponse.status ?? 'network'}/${
+            userResponse.status ?? 'network'
+          })`,
+        );
+      }
+
+      setTagSuggestions(tagResponse.data);
+      setUserSuggestions(userResponse.data);
       setShowSuggestions(true);
     } catch (error) {
+      if (requestId !== suggestionRequestRef.current) return;
       logger.error(`Error fetching users and tags: ${error}`);
       setTagSuggestions([]);
       setUserSuggestions([]);
@@ -96,11 +124,34 @@ const GlobalSearchBar = ({
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setQuery(value);
-    findSuggestions(value);
-    onSearch(value);
+
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+    }
+
+    const requestId = ++suggestionRequestRef.current;
+
+    if (value.trim() === '') {
+      setTagSuggestions([]);
+      setUserSuggestions([]);
+      setShowSuggestions(false);
+      onSearch('');
+      return;
+    }
+
+    searchTimerRef.current = setTimeout(() => {
+      findSuggestions(value, requestId);
+      onSearch(value);
+    }, 300);
   };
 
   const handleSubmit = () => {
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = null;
+    }
+    const requestId = ++suggestionRequestRef.current;
+    findSuggestions(query, requestId);
     onSearch(query);
   };
 
@@ -122,6 +173,11 @@ const GlobalSearchBar = ({
     setTagSuggestions([]);
     setUserSuggestions([]);
     setShowSuggestions(false);
+    suggestionRequestRef.current += 1;
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = null;
+    }
     onClear?.();
   };
 
@@ -160,6 +216,11 @@ const GlobalSearchBar = ({
     setShowSuggestions(false);
     setTagSuggestions([]);
     setUserSuggestions([]);
+    suggestionRequestRef.current += 1;
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = null;
+    }
     onSearch(value);
   };
 

--- a/frontend/src/pages/globalSearch/globalSearch.test.ts
+++ b/frontend/src/pages/globalSearch/globalSearch.test.ts
@@ -1,0 +1,13 @@
+import { normalizeSearchValue } from './globalSearch';
+
+describe('global search normalization', () => {
+  it('normalizes strings and accents', () => {
+    expect(normalizeSearchValue('Événement TEST')).toBe('evenement test');
+  });
+
+  it('does not crash on non-string API values', () => {
+    expect(normalizeSearchValue(['Mot-clé', 2026])).toBe('mot-cle 2026');
+    expect(normalizeSearchValue({ unexpected: 'value' })).toBe('');
+    expect(normalizeSearchValue(null)).toBe('');
+  });
+});

--- a/frontend/src/pages/globalSearch/globalSearch.tsx
+++ b/frontend/src/pages/globalSearch/globalSearch.tsx
@@ -18,14 +18,26 @@ import { EventStatus } from '../../utils/EventStatus';
 import { useBrandingContext } from '../../context/BrandingContext';
 import logger from '../../utils/logger';
 
-const removeAccents = (value: string): string =>
-  value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+const toSearchableText = (value: unknown): string => {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(toSearchableText).filter(Boolean).join(' ');
+  }
+  return '';
+};
 
-const normalize = (value: string): string => removeAccents(value).toLowerCase();
+export const normalizeSearchValue = (value: unknown): string =>
+  toSearchableText(value)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
 
-const matches = (haystack: string, query: string): boolean => {
+const matches = (haystack: unknown, query: string): boolean => {
   if (!query.trim()) return false;
-  return normalize(haystack).includes(normalize(query));
+  return normalizeSearchValue(haystack).includes(normalizeSearchValue(query));
 };
 
 interface GlobalSearchFilters {
@@ -73,10 +85,10 @@ const matchesAnySelected = (
 
   const normalizedCandidates = candidateValues
     .filter(Boolean)
-    .map((value) => normalize(value as string));
+    .map(normalizeSearchValue);
 
   return selectedValues.some((selectedValue) =>
-    normalizedCandidates.includes(normalize(selectedValue)),
+    normalizedCandidates.includes(normalizeSearchValue(selectedValue)),
   );
 };
 
@@ -102,15 +114,13 @@ const matchesSelectedTags = (
 
   return itemTags.some((tag) =>
     selectedTags.some(
-      (selectedTag) => normalize(tag ?? '') === normalize(selectedTag),
+      (selectedTag) =>
+        normalizeSearchValue(tag) === normalizeSearchValue(selectedTag),
     ),
   );
 };
 
-const matchesTextQuery = (
-  fields: Array<string | null | undefined>,
-  query: string,
-): boolean => {
+const matchesTextQuery = (fields: unknown[], query: string): boolean => {
   if (!query.trim()) return true;
   return fields.some((field) => matches(field ?? '', query));
 };
@@ -282,8 +292,17 @@ const GlobalSearchPage = () => {
 
         if (!active) return;
 
-        setVideos(videosResponse.data || []);
-        setEvents(eventsResponse.data || []);
+        if (
+          !videosResponse.ok ||
+          !Array.isArray(videosResponse.data) ||
+          !eventsResponse.ok ||
+          !Array.isArray(eventsResponse.data)
+        ) {
+          throw new Error('Unexpected global search response');
+        }
+
+        setVideos(videosResponse.data);
+        setEvents(eventsResponse.data);
         setFallbackMiniatureUrl(
           fallbackResponse || '/branding/exemple/image_tuile_event.png',
         );

--- a/frontend/src/pages/profile/profile.tsx
+++ b/frontend/src/pages/profile/profile.tsx
@@ -49,7 +49,9 @@ const Profile: FC<ProfileProps> = () => {
     async (userId: string, isCurrentUserProfile: boolean = false) => {
       try {
         const videosResponse = await getVideosByUser(userId);
-        setVideos(videosResponse.data || []);
+        setVideos(
+          Array.isArray(videosResponse.data) ? videosResponse.data : [],
+        );
 
         const userResponse = await getUsers();
         const user = userResponse.data.find((u: User) => u.id === userId);
@@ -117,11 +119,13 @@ const Profile: FC<ProfileProps> = () => {
     try {
       if (keywords[0] !== '') {
         const response = await searchVideos(keywords[0]);
-        setVideos(response.data || []);
+        setVideos(Array.isArray(response.data) ? response.data : []);
       } else {
         const backendUser = JSON.parse(userString!);
         const videosResponse = await getVideosByUser(backendUser.id);
-        setVideos(videosResponse.data || []);
+        setVideos(
+          Array.isArray(videosResponse.data) ? videosResponse.data : [],
+        );
       }
     } catch (error) {
       console.error('Error fetching suggestions:', error);

--- a/frontend/src/pages/videos/videos.tsx
+++ b/frontend/src/pages/videos/videos.tsx
@@ -38,8 +38,8 @@ const parseQueryParams = (search: string): SearchState => {
       params.get('archived') === 'true'
         ? true
         : params.get('archived') === 'false'
-          ? false
-          : null,
+        ? false
+        : null,
   };
 };
 
@@ -149,12 +149,17 @@ const Videos: FC<VideosProps> = () => {
     try {
       if (keywords[0] !== '') {
         const response = await searchVideos(keywords[0]);
-
-        const result = response.data || [];
+        const result = Array.isArray(response.data) ? response.data : [];
+        if (!response.ok || !Array.isArray(response.data)) {
+          logger.warn(
+            { status: response.status },
+            'Video search returned an invalid response',
+          );
+        }
         setVideos(result);
       } else {
         const response = await getVideos();
-        const result = response.data || [];
+        const result = Array.isArray(response.data) ? response.data : [];
         setVideos(result);
       }
     } catch (error) {
@@ -173,16 +178,18 @@ const Videos: FC<VideosProps> = () => {
       let result = [...videos];
 
       if (newFilters.tags.length > 0) {
-        result = result.filter((video) =>
-          video.tags?.some((tag) => newFilters.tags.includes(tag.name)),
+        result = result.filter(
+          (video) =>
+            video.tags?.some((tag) => newFilters.tags.includes(tag.name)),
         );
       }
 
       if (newFilters.users.length > 0) {
         result = result.filter((video) => {
           const uname = video.creator?.username;
-          const fullname =
-            `${video.creator?.firstName ?? ''} ${video.creator?.lastName ?? ''}`.trim();
+          const fullname = `${video.creator?.firstName ?? ''} ${
+            video.creator?.lastName ?? ''
+          }`.trim();
           return newFilters.users.includes(uname || fullname);
         });
       }
@@ -252,22 +259,30 @@ const Videos: FC<VideosProps> = () => {
         const res = initialParams.favoris
           ? await getFavoriteVideos()
           : await getVideos();
-        const allVideos = res.data || [];
+        const allVideos = Array.isArray(res.data) ? res.data : [];
+        if (!res.ok || !Array.isArray(res.data)) {
+          logger.warn(
+            { status: res.status },
+            'Video list returned an invalid response',
+          );
+        }
         setVideos(allVideos);
 
         let result = [...allVideos];
         if (initialParams.tags.length > 0) {
-          result = result.filter((v) =>
-            v.tags?.some((tag: { name: string }) =>
-              initialParams.tags.includes(tag.name),
-            ),
+          result = result.filter(
+            (v) =>
+              v.tags?.some((tag: { name: string }) =>
+                initialParams.tags.includes(tag.name),
+              ),
           );
         }
         if (initialParams.users.length > 0) {
           result = result.filter((v) => {
             const uname = v.creator?.username;
-            const fullname =
-              `${v.creator?.firstName ?? ''} ${v.creator?.lastName ?? ''}`.trim();
+            const fullname = `${v.creator?.firstName ?? ''} ${
+              v.creator?.lastName ?? ''
+            }`.trim();
             return initialParams.users.includes(uname || fullname);
           });
         }
@@ -414,7 +429,9 @@ const Videos: FC<VideosProps> = () => {
                 creatorId={video.creator?.id || ''}
                 createBy={
                   video.creator?.username ||
-                  `${video.creator?.firstName ?? ''} ${video.creator?.lastName ?? ''}`.trim()
+                  `${video.creator?.firstName ?? ''} ${
+                    video.creator?.lastName ?? ''
+                  }`.trim()
                 }
                 views={video.views}
                 createdAt={video.createdAt.toString()}

--- a/frontend/src/utils/ProtectedRoutes.test.tsx
+++ b/frontend/src/utils/ProtectedRoutes.test.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useAuth } from 'react-oidc-context';
+import { api, loginUser } from './api';
+import { ProtectedRoutes } from './ProtectedRoutes';
+
+jest.mock('react-oidc-context', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('./api', () => ({
+  api: {
+    setHeaders: jest.fn(),
+    deleteHeader: jest.fn(),
+  },
+  loginUser: jest.fn(),
+}));
+
+const mockedUseAuth = useAuth as jest.Mock;
+const mockedSetHeaders = api.setHeaders as jest.Mock;
+const mockedLoginUser = loginUser as jest.Mock;
+
+describe('ProtectedRoutes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedLoginUser.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: { id: 'user-id' },
+    });
+    mockedUseAuth.mockReturnValue({
+      activeNavigator: null,
+      isAuthenticated: true,
+      isLoading: false,
+      user: {
+        access_token: 'current-token',
+        expired: false,
+      },
+      signinRedirect: jest.fn(),
+      signinSilent: jest.fn(),
+      removeUser: jest.fn(),
+    });
+  });
+
+  it('configures the current token before protected child effects run', async () => {
+    const childRequest = jest.fn();
+
+    const ProtectedChild = () => {
+      useEffect(() => {
+        childRequest();
+      }, []);
+
+      return <div>Protected content</div>;
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/search?q=test']}>
+        <ProtectedRoutes>
+          <ProtectedChild />
+        </ProtectedRoutes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('Protected content');
+    await waitFor(() => expect(childRequest).toHaveBeenCalledTimes(1));
+
+    expect(mockedSetHeaders).toHaveBeenCalledWith({
+      Authorization: 'Bearer current-token',
+    });
+    expect(mockedSetHeaders.mock.invocationCallOrder[0]).toBeLessThan(
+      childRequest.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/frontend/src/utils/ProtectedRoutes.tsx
+++ b/frontend/src/utils/ProtectedRoutes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { useNavigate, useLocation } from 'react-router-dom';
 import LoadingPage from '../pages/Loading/Loading';
@@ -21,6 +21,26 @@ export function ProtectedRoutes(props: ProtectedRoutesProps) {
   } = auth;
   const navigate = useNavigate();
   const location = useLocation();
+  const [configuredAccessToken, setConfiguredAccessToken] = useState<
+    string | null
+  >(null);
+
+  // Do not mount protected pages until their API requests are guaranteed to
+  // carry the current OIDC token. Child effects can otherwise race the
+  // passive authentication effect after a direct navigation or token renewal.
+  useLayoutEffect(() => {
+    const accessToken =
+      oidcUser && !oidcUser.expired ? oidcUser.access_token : null;
+
+    if (accessToken) {
+      api.setHeaders({ Authorization: `Bearer ${accessToken}` });
+      setConfiguredAccessToken(accessToken);
+      return;
+    }
+
+    api.deleteHeader('Authorization');
+    setConfiguredAccessToken(null);
+  }, [oidcUser]);
 
   // Mettre à jour le token dans localStorage quand le token change (ex: renouvellement)
   useEffect(() => {
@@ -116,7 +136,11 @@ export function ProtectedRoutes(props: ProtectedRoutesProps) {
     navigate,
   ]);
 
-  if (isAuthenticated) {
+  if (
+    isAuthenticated &&
+    oidcUser?.access_token &&
+    configuredAccessToken === oidcUser.access_token
+  ) {
     return <>{props.children}</>;
   }
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -38,14 +38,14 @@ export const updateProfileWithoutImage = (newProfile) =>
 export const createEvent = (event) => api.post('/events', event);
 export const getPublishedEvents = async () => {
   const res = await api.get('/events?closed=false');
-  if (res.status !== 200 || !res.data || typeof res.data !== 'object') {
+  if (res.status !== 200 || !Array.isArray(res.data)) {
     throw new Error('Erreur lors de la récupération des événements publiés');
   }
   return res;
 };
 export const getUnpublishedEvents = async () => {
   const res = await api.get(`/events/unpublished?closed=false&published=false`);
-  if (res.status !== 200 || !res.data || typeof res.data !== 'object') {
+  if (res.status !== 200 || !Array.isArray(res.data)) {
     throw new Error(
       'Erreur lors de la récupération des événements non publiés',
     );
@@ -54,7 +54,7 @@ export const getUnpublishedEvents = async () => {
 };
 export const getClosedEvents = async () => {
   const res = await api.get('/events?closed=true');
-  if (res.status !== 200 || !res.data || typeof res.data !== 'object') {
+  if (res.status !== 200 || !Array.isArray(res.data)) {
     throw new Error('Erreur lors de la récupération des événements clos');
   }
   return res;

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -12,15 +12,6 @@ export const api = create({
   },
 });
 
-api.addAsyncRequestTransform(async (request) => {
-  const userString = localStorage.getItem('backendUser');
-  const user = userString ? JSON.parse(userString) : null;
-
-  if (user?.token) {
-    request.headers['Authorization'] = `Bearer ${user.token}`;
-  }
-});
-
 // Public API instance without authentication
 export const publicApi = create({
   baseURL: `${getEnv('REACT_APP_API_URL')}:${getEnv('REACT_APP_API_PORT')}/api`,
@@ -112,9 +103,10 @@ export const createTag = (data) => api.post('/tags', data);
 export const modifyVideo = (formData) => api.post('/videos/modify', formData);
 export const getVideosByUser = (userId) => api.get(`/videos/` + userId);
 export const findTag = (name) => api.get(`/tags?name=${name}`);
-export const findTags = (tag) => api.get(`/tags/find?value=${tag}`);
-export const findUsers = (user) => api.get(`/users/find?value=${user}`);
-export const searchVideos = (data) => api.get(`/videos/searchvideo/${data}`);
+export const findTags = (tag) => api.get('/tags/find', { value: tag });
+export const findUsers = (user) => api.get('/users/find', { value: user });
+export const searchVideos = (data) =>
+  api.get(`/videos/searchvideo/${encodeURIComponent(data)}`);
 export const getVideoSuggestions = (id) =>
   api.get(`/videos/videoSuggestions/${id}`);
 export const incrementVideoViews = (videoId) =>


### PR DESCRIPTION
## Problèmes corrigés
- empêche les réponses HTTP d’erreur d’être traitées comme des tableaux
- normalise sans crash les champs de recherche non textuels, notamment `track.keywords`
- configure le token OIDC avant le montage des pages protégées afin d’éviter les requêtes sans `Authorization`
- ajoute un debounce et ignore les réponses de suggestions obsolètes
- remplace les métadonnées CRA par les métadonnées de partage OchoCast, agnostiques à OCTO

## Validation locale
- TypeScript : OK
- ESLint : 0 erreur (6 avertissements préexistants)
- 5 tests ciblés : OK
- build production : OK